### PR TITLE
Add extra files needed for dracut

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -71,7 +71,7 @@ build-dracut:
     ARG REMOVE_COS_MODULE
     COPY +build-immucore/immucore /usr/bin/immucore
     COPY --dir dracut/28immucore /usr/lib/dracut/modules.d/
-    COPY dracut/dracut.conf /etc/dracut.conf.d/10-immucore.conf
+    COPY dracut/10-immucore.conf /etc/dracut.conf.d/10-immucore.conf
     # Remove cos-immutable-rootfs module
     RUN rm -Rf /usr/lib/dracut/modules.d/30cos-immutable-rootfs/
     RUN rm /etc/dracut.conf.d/02-cos-immutable-rootfs.conf

--- a/Earthfile
+++ b/Earthfile
@@ -71,10 +71,14 @@ build-dracut:
     ARG REMOVE_COS_MODULE
     COPY +build-immucore/immucore /usr/bin/immucore
     COPY --dir dracut/28immucore /usr/lib/dracut/modules.d/
-    COPY dracut/10-immucore.conf /etc/dracut.conf.d/10-immucore.conf
-    # Remove cos-immutable-rootfs module
+    COPY dracut/*.conf /etc/dracut.conf.d/
+    RUN ls -ltra /etc/dracut.conf.d/
+    # (START) Remove cos-immutable-rootfs module
     RUN rm -Rf /usr/lib/dracut/modules.d/30cos-immutable-rootfs/
     RUN rm /etc/dracut.conf.d/02-cos-immutable-rootfs.conf
+    RUN rm /etc/dracut.conf.d/02-cos-setup-initramfs.conf
+    RUN rm /etc/dracut.conf.d/50-cos-initrd.conf
+    # (END) Remove cos-immutable-rootfs module
     RUN kernel=$(ls /lib/modules | head -n1) && \
         dracut -f "/boot/initrd-${kernel}" "${kernel}" && \
         ln -sf "initrd-${kernel}" /boot/initrd

--- a/dracut/02-kairos-setup-initramfs.conf
+++ b/dracut/02-kairos-setup-initramfs.conf
@@ -1,0 +1,2 @@
+install_items+=" /etc/hosts "
+add_dracutmodules+=" network "

--- a/dracut/10-immucore.conf
+++ b/dracut/10-immucore.conf
@@ -1,8 +1,6 @@
-# This services should be run from immucore directly, rootfs once we mount /sysroot and initramfs once we mount everything,
+# This services should be run from immucore directly, initramfs once we mount everything,
 # so at the end, just before we let init do the switch_root. Notice that we run really early in the boot with immucore so
 # maybe by this time some things are not ready...
 # Note that initramfs run with RootDirectory=/sysroot
 install_items+=" /etc/systemd/system/cos-setup-initramfs.service /etc/systemd/system/initrd.target.requires/cos-setup-initramfs.service "
-# RUN BY IMMUCORE BUT FAILING
-#install_items+=" /etc/systemd/system/cos-setup-rootfs.service /etc/systemd/system/initrd-fs.target.requires/cos-setup-rootfs.service "
 add_dracutmodules+=" immucore "

--- a/dracut/28immucore/kairos-setup-initramfs.service
+++ b/dracut/28immucore/kairos-setup-initramfs.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=kairos system initramfs setup before switch root
+DefaultDependencies=no
+After=initrd-fs.target
+Requires=initrd-fs.target
+Before=initrd.target
+
+[Service]
+RootDirectory=/sysroot
+BindPaths=/proc /sys /dev /run /tmp
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/elemental run-stage initramfs
+
+[Install]
+RequiredBy=initrd.target

--- a/dracut/28immucore/module-setup.sh
+++ b/dracut/28immucore/module-setup.sh
@@ -23,7 +23,6 @@ install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}
     declare systemdsystemunitdir=${systemdsystemunitdir}
-    declare initdir=${initdir}
 
     # Add missing elemental binary, drop once we get yip lib inside immucore as its only needed to run the stages
     inst_multiple immucore elemental

--- a/dracut/28immucore/module-setup.sh
+++ b/dracut/28immucore/module-setup.sh
@@ -34,5 +34,11 @@ install() {
     inst_simple "${moddir}/immucore.service" "${systemdsystemunitdir}/immucore.service"
     mkdir -p "${initdir}/${systemdsystemunitdir}/initrd-fs.target.requires"
     ln_r "../immucore.service" "${systemdsystemunitdir}/initrd-fs.target.requires/immucore.service"
+
+    # Until this is done on immucore, we need to ship it as part of the dracut module
+    inst_simple "${moddir}/kairos-setup-initramfs.service" "${systemdsystemunitdir}/kairos-setup-initramfs.service"
+    mkdir -p "${initdir}/${systemdsystemunitdir}/initrd.target.requires"
+    ln_r "../kairos-setup-initramfs.service" "${systemdsystemunitdir}/initrd.target.requires/kairos-setup-initramfs.service"
+
     dracut_need_initqueue
 }

--- a/dracut/50-kairos-initrd.conf
+++ b/dracut/50-kairos-initrd.conf
@@ -1,0 +1,5 @@
+hostonly_cmdline="no"
+hostonly="no"
+compress="xz"
+omit_dracutmodules+=" multipath "
+add_dracutmodules+=" livenet dmsquash-live "

--- a/earthly.sh
+++ b/earthly.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm -t -v $(pwd):/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.6.21 --allow-privileged $@
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm -t -v $(pwd):/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.6.30 --allow-privileged $@


### PR DESCRIPTION
If we are dropping cos-immutable-rootfs then we have to include the missing files that the package already added.

For example, the several dracut configs of modules for the initramfs stage, or the general config for the dracut file.

We also need to install and link the initramfs elemental stage service as that its no longer provided by the cos-immutable-rootfs package and not integrated into immucore yet

Signed-off-by: Itxaka <itxaka.garcia@spectrocloud.com>