### PR TITLE
Add fsck before mounting

### DIFF
--- a/pkg/mount/dag_steps.go
+++ b/pkg/mount/dag_steps.go
@@ -56,7 +56,7 @@ func (s *State) MountRootDagStep(g *herd.Graph) error {
 					log.Logger.Debug().Str("targetImage", s.TargetImage).Str("path", s.Rootdir).Str("TargetDevice", s.TargetDevice).Msg("Not mounting loop, already mounted")
 					return nil
 				}
-				// TODO: squashfs recovery image?
+				_ = internalUtils.Fsck(s.path("/run/initramfs/cos-state", s.TargetImage))
 				cmd := fmt.Sprintf("losetup --show -f %s", s.path("/run/initramfs/cos-state", s.TargetImage))
 				_, err := utils.SH(cmd)
 				s.LogIfError(err, "losetup")

--- a/pkg/mount/state.go
+++ b/pkg/mount/state.go
@@ -116,6 +116,10 @@ func (s *State) MountOP(what, where, t string, options []string, timeout time.Du
 					MountOption: mountPoint,
 					FstabEntry:  *tmpFstab,
 					Target:      where,
+					PrepareCallback: func() error {
+						_ = internalUtils.Fsck(what)
+						return nil
+					},
 				}
 
 				err = op.run()


### PR DESCRIPTION
Respect all options from systemd-fsck as that it what is currently used on kairos.

Fixes #55 