### PR TITLE
Add missing cmdline stanzas

### DIFF
--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -5,6 +5,7 @@ import (
 	"github.com/containerd/containerd/mount"
 	"github.com/deniswernert/go-fstab"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 )
@@ -180,5 +181,30 @@ func MountProc() {
 	if !IsMounted("/proc") {
 		_ = syscall.Mount("proc", "/proc", "proc", syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "")
 	}
+
+}
+
+// GetOemTimeout parses the cmdline to get the oem timeout to use. Defaults to 5 (converted into seconds afterwards)
+func GetOemTimeout() int {
+	time := ReadCMDLineArg("rd.cos.oemtimeout=")
+	if len(time) == 0 {
+		return 5
+	}
+	converted, err := strconv.Atoi(time[1])
+	if err != nil {
+		return 5
+	}
+	return converted
+}
+
+// GetOverlayBase parses the cdmline and gets the overlay config
+// Format is rd.cos.overlay=tmpfs:20% or rd.cos.overlay=LABEL=$LABEL or rd.cos.overlay=UUID=$UUID
+func GetOverlayBase() string {
+	overlayConfig := ReadCMDLineArg("rd.cos.overlay=")
+	if len(overlayConfig) == 0 {
+		return "tmpfs:20%"
+	}
+
+	return overlayConfig[1]
 
 }

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ func main() {
 			TargetDevice:  targetDevice,
 			TargetImage:   targetImage,
 			RootMountMode: utils.RootRW(),
+			OemTimout:     utils.GetOemTimeout(),
+			OverlayBase:   utils.GetOverlayBase(),
 		}
 
 		if utils.DisableImmucore() {

--- a/pkg/mount/dag_steps.go
+++ b/pkg/mount/dag_steps.go
@@ -184,7 +184,7 @@ func (s *State) MountOemDagStep(g *herd.Graph, deps ...string) error {
 					//"noauto",
 					//"nouser",
 					"async",
-				}, 10*time.Second),
+				}, time.Duration(s.OemTimout)*time.Second),
 		),
 	)
 }
@@ -196,7 +196,7 @@ func (s *State) MountBaseOverlayDagStep(g *herd.Graph) error {
 			func(ctx context.Context) error {
 				op, err := baseOverlay(Overlay{
 					Base:        "/run/overlay",
-					BackingBase: "tmpfs:20%",
+					BackingBase: s.OverlayBase,
 				})
 				if err != nil {
 					return err

--- a/pkg/mount/state.go
+++ b/pkg/mount/state.go
@@ -28,6 +28,9 @@ type State struct {
 	BindMounts   []string          // e.g. /etc/kubernetes
 	CustomMounts map[string]string // e.g. diskid : mountpoint
 
+	OverlayBase string // Overlay config, defaults to tmpfs:20%
+	OemTimout   int    // Time to wait for the oem to time out if not found, defaults to 5s
+
 	StateDir string // e.g. "/usr/local/.state"
 	fstabs   []*fstab.Mount
 }


### PR DESCRIPTION
Adds support for:
 - rd.cos.oemtimeout=
 - rd.cos.overlay=tmpfs:SIZE
 - rd.cos.overlay=LABEL=DEVICE_LABEL
 - rd.cos.overlay=UUID=DEVICE_UUID

Fixes https://github.com/kairos-io/kairos/issues/991