### PR TITLE
:bug: Fix chroot unmounting

### DIFF
--- a/pkg/mount/state.go
+++ b/pkg/mount/state.go
@@ -95,7 +95,6 @@ func (s *State) RunStageOp(stage string) func(context.Context) error {
 			}
 			output, err := utils.SH(cmd)
 			internalUtils.Log.Info().Msg("Running rootfs stage")
-			internalUtils.Log.Info().Msg(output)
 			f, ferr := os.Create(filepath.Join(constants.LogDir, "rootfs_stage.log"))
 			if ferr == nil {
 				_, _ = f.WriteString(output)
@@ -104,10 +103,9 @@ func (s *State) RunStageOp(stage string) func(context.Context) error {
 			return err
 		case "initramfs":
 			// Not sure if it will work under UKI where the s.Rootdir is the current root already
+			internalUtils.Log.Info().Msg("Running initramfs stage")
 			chroot := internalUtils.NewChroot(s.Rootdir)
 			output, err := chroot.Run(cmd)
-			internalUtils.Log.Info().Msg("Running initramfs stage")
-			internalUtils.Log.Info().Msg(output)
 			f, ferr := os.Create(filepath.Join(constants.LogDir, "initramfs_stage.log"))
 			if ferr == nil {
 				_, _ = f.WriteString(output)


### PR DESCRIPTION
We were mounting the whole /dev /sys and /run as MS_REC which means that it was also mounting any submounts that those original source had mounted.

This resulted in things like the /dev/sr0 or /sys/fs/cgroups/blkid subdirs being mounted and shared with the initramfs. Which means that trying to unmount them also tried to unmount them from initramfs and thatis a big no-no

This patch makes it so the specifics dirs that we need are mounted as MS_REC and the rest are normally mounted. It means we have to be more specific with our mounts for chroot and that we need to do checks before mounting (i.e. /run/rootfsbase doesnt exist in a normal mount) before mounting everything but this sets and clean the chroot correctly.