### PR TITLE
:seedling: Add kcrypt binary to initramfs

### DIFF
--- a/dracut/28immucore/module-setup.sh
+++ b/dracut/28immucore/module-setup.sh
@@ -24,7 +24,7 @@ install() {
 
     inst_multiple immucore
     # add utils used by yip stages
-    inst_multiple partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat blkid e2fsck resize2fs mount umount sgdisk rsync
+    inst_multiple kcrypt partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat blkid e2fsck resize2fs mount umount sgdisk rsync
     # missing mkfs.xfs xfs_growfs in image?
     inst_script "${moddir}/generator.sh" "${systemdutildir}/system-generators/immucore-generator"
     inst_simple "${moddir}/immucore.service" "${systemdsystemunitdir}/immucore.service"


### PR DESCRIPTION
So we can run kcrypt as part of the stages inside the initramfs