### PR TITLE
Fix missing sysroot mount in fstab

### DIFF
--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -66,7 +66,7 @@ func IsMounted(dev string) bool {
 func DiskFSType(s string) string {
 	out, e := CommandWithPath(fmt.Sprintf("blkid %s -s TYPE -o value", s))
 	if e != nil {
-		Log.Err(e).Msg("blkid")
+		Log.Debug().Err(e).Msg("blkid")
 	}
 	out = strings.Trim(strings.Trim(out, " "), "\n")
 	Log.Debug().Str("what", s).Str("type", out).Msg("Partition FS type")
@@ -123,6 +123,7 @@ func CleanSysrootForFstab(path string) string {
 	if cleaned == "" {
 		cleaned = "/"
 	}
+	Log.Debug().Str("old", path).Str("new", cleaned).Msg("Cleaning for sysroot")
 	return cleaned
 }
 

--- a/pkg/mount/dag_steps.go
+++ b/pkg/mount/dag_steps.go
@@ -90,8 +90,6 @@ func (s *State) MountRootDagStep(g *herd.Graph) error {
 					"suid",
 					"dev",
 					"exec",
-					// "auto",
-					//"nouser",
 					"async",
 				}, 10*time.Second),
 		),

--- a/pkg/mount/operation.go
+++ b/pkg/mount/operation.go
@@ -18,11 +18,11 @@ type mountOperation struct {
 
 func (m mountOperation) run() error {
 	// Add context to sublogger
-	l := internalUtils.Log.With().Str("what", m.MountOption.Source).Str("where", m.Target).Str("type", m.MountOption.Type).Strs("options", m.MountOption.Options).Logger().Level(zerolog.InfoLevel)
+	l := internalUtils.Log.With().Str("what", m.MountOption.Source).Str("where", m.Target).Str("type", m.MountOption.Type).Strs("options", m.MountOption.Options).Logger()
 	// Not sure why this defaults to debuglevel when creating a sublogger, so make sure we set it properly
 	debug := len(internalUtils.ReadCMDLineArg("rd.immucore.debug")) > 0
 	if debug {
-		l.Level(zerolog.DebugLevel)
+		l = l.Level(zerolog.DebugLevel)
 	}
 
 	if m.PrepareCallback != nil {


### PR DESCRIPTION
sysroot mount was not being added to fstab due a combination of systemd mounting it (so it errored out as already mounted) and fstab ignoring that already mounted partition

Now we have a method of adding and avoiding duplicated entries and a check for that exact error