### PR TITLE
Move some err to warnings

### DIFF
--- a/pkg/mount/dag_steps.go
+++ b/pkg/mount/dag_steps.go
@@ -291,7 +291,7 @@ func (s *State) MountCustomMountsDagStep(g *herd.Graph) error {
 				}
 				internalUtils.Log.Debug().Str("what", what).Str("where", where).Msg("Custom mount done")
 			}
-			internalUtils.Log.Err(err.ErrorOrNil()).Send()
+			internalUtils.Log.Warn().Err(err.ErrorOrNil()).Send()
 
 			return err.ErrorOrNil()
 		}),
@@ -323,7 +323,7 @@ func (s *State) MountCustomBindsDagStep(g *herd.Graph) error {
 					}
 					internalUtils.Log.Debug().Str("what", p).Msg("Bind mount end")
 				}
-				internalUtils.Log.Err(err.ErrorOrNil()).Send()
+				internalUtils.Log.Warn().Err(err.ErrorOrNil()).Send()
 				return err.ErrorOrNil()
 			},
 		),

--- a/pkg/mount/operation.go
+++ b/pkg/mount/operation.go
@@ -27,14 +27,14 @@ func (m mountOperation) run() error {
 
 	if m.PrepareCallback != nil {
 		if err := m.PrepareCallback(); err != nil {
-			l.Err(err).Msg("executing mount callback")
+			l.Warn().Err(err).Msg("executing mount callback")
 			return err
 		}
 	}
 	//TODO: not only check if mounted but also if the type,options and source are the same?
 	mounted, err := mountinfo.Mounted(m.Target)
 	if err != nil {
-		l.Err(err).Msg("checking mount status")
+		l.Warn().Err(err).Msg("checking mount status")
 		return err
 	}
 	if mounted {


### PR DESCRIPTION
As they are not critical, we can advise over them to pinpoint to a wrong config, but they are not critical and we dont expect them to work to have a working system

Fixes: https://github.com/kairos-io/kairos/issues/1367