### PR TITLE
Set basic /run mount from the start to be able to always log

### DIFF
--- a/internal/utils/log.go
+++ b/internal/utils/log.go
@@ -26,7 +26,7 @@ func SetLogger() {
 		loggers = append(loggers, zerolog.ConsoleWriter{Out: logFile})
 	}
 
-	loggers = append(loggers, zerolog.ConsoleWriter{Out: os.Stderr})
+	loggers = append(loggers, zerolog.NewConsoleWriter())
 
 	multi := zerolog.MultiLevelWriter(loggers...)
 	level = zerolog.InfoLevel

--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -194,15 +194,19 @@ func Fsck(device string) error {
 	return e
 }
 
-// MountProc will mount /proc
+// MountBasic will mount /proc and /run
 // For now proc is needed to read the cmdline fully in uki mode
 // in normal modes this should already be done by the initramfs process, so we can skip this.
-func MountProc() {
+// /run is needed to start logging from the start
+func MountBasic() {
 	_ = os.MkdirAll("/proc", 0755)
 	if !IsMounted("/proc") {
 		_ = syscall.Mount("proc", "/proc", "proc", syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "")
 	}
-
+	_ = os.MkdirAll("/run", 0755)
+	if !IsMounted("/run") {
+		_ = syscall.Mount("tmpfs", "/run", "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "mode=755")
+	}
 }
 
 // GetOemTimeout parses the cmdline to get the oem timeout to use. Defaults to 5 (converted into seconds afterwards).

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 		var targetDevice, targetImage string
 		var state *mount.State
 
-		utils.MountProc()
+		utils.MountBasic()
 		utils.SetLogger()
 
 		v := version.Get()

--- a/pkg/mount/dag_steps.go
+++ b/pkg/mount/dag_steps.go
@@ -404,13 +404,6 @@ func (s *State) UKIMountBaseSystem(g *herd.Graph) error {
 				var err error
 				mounts := []mount{
 					{
-						"/run",
-						"tmpfs",
-						"tmpfs",
-						syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_RELATIME,
-						"mode=755",
-					},
-					{
 						"/sys",
 						"sysfs",
 						"sysfs",
@@ -438,6 +431,7 @@ func (s *State) UKIMountBaseSystem(g *herd.Graph) error {
 						err = multierror.Append(err, e)
 						internalUtils.Log.Err(e).Msg("Creating dir")
 					}
+
 					e = syscall.Mount(m.what, m.where, m.fs, m.flags, m.data)
 					if e != nil {
 						err = multierror.Append(err, e)


### PR DESCRIPTION
Otherwise under uki, it cannot write the log to /run as it doesnt exist yet and then on boot we lose the full log of immucore which is bad for troubleshooting