### PR TITLE
measure PCR phase

### DIFF
--- a/pkg/mount/dag_steps.go
+++ b/pkg/mount/dag_steps.go
@@ -462,6 +462,12 @@ func (s *State) UKIMountBaseSystem(g *herd.Graph) error {
 						internalUtils.Log.Err(e).Str("what", m.what).Str("where", m.where).Str("type", m.fs).Msg("Mounting")
 					}
 				}
+				output, err := internalUtils.CommandWithPath("/usr/lib/systemd/systemd-pcrphase --graceful enter-initrd")
+				if err != nil {
+					internalUtils.Log.Err(err).Msg("running systemd-pcrphase")
+					return err
+				}
+				internalUtils.Log.Debug().Str("out", output).Msg("systemd-pcrphase enter-initrd")
 				return err
 			},
 		),
@@ -476,6 +482,12 @@ func (s *State) UKIBootInitDagStep(g *herd.Graph) error {
 		herd.WeakDeps,
 		herd.WithWeakDeps(cnst.OpRemountRootRO, cnst.OpRootfsHook, cnst.OpInitramfsHook, cnst.OpWriteFstab),
 		herd.WithCallback(func(ctx context.Context) error {
+			output, err := internalUtils.CommandWithPath("/usr/lib/systemd/systemd-pcrphase --graceful leave-initrd")
+			if err != nil {
+				internalUtils.Log.Err(err).Msg("running systemd-pcrphase")
+				return err
+			}
+			internalUtils.Log.Debug().Str("out", output).Msg("systemd-pcrphase leave-initrd")
 			// Print dag before exit, otherwise its never printed as we never exit the program
 			internalUtils.Log.Info().Msg(s.WriteDAG(g))
 			internalUtils.Log.Debug().Msg("Executing init callback!")


### PR DESCRIPTION
Usually systemd initrd takes care of adding the measurements to the PCR registers, but as we take over the initrd, nothing was being added, thus the final measurements didnt match.

This mimics systemd calling the measurements at the start of initrd and at the end of it, so later stages can extend the PCRs correctly