### PR TITLE
Mount cdrom efiboot contents under /run/rootfsbase

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -11,46 +11,48 @@ func GetCloudInitPaths() []string {
 	return []string{"/system/oem", "/oem/", "/usr/local/cloud-config/"}
 }
 
-// GenericKernelDrivers retusn a list of generic kernel drivers to insmod during uki mode
+// GenericKernelDrivers returns a list of generic kernel drivers to insmod during uki mode
 // as they could be useful for a lot of situations.
 func GenericKernelDrivers() []string {
-	return []string{"virtio", "ata_piix", "cdrom", "ext4", "iso9660", "usb_storage", "ahci",
-		"virtio_blk", "virtio_scsi", "virtio_net", "nvme", "overlay", "libata", "sr_mod", "simpledrm"}
+	return []string{"virtio", "ata_piix", "cdrom", "ext4", "iso9660", "usb_storage", "ahci", "fat", "vfat",
+		"virtio_blk", "virtio_scsi", "virtio_net", "nvme", "overlay", "libata", "sr_mod", "simpledrm", "loop"}
 }
 
 var ErrAlreadyMounted = errors.New("already mounted")
 
 const (
-	OpCustomMounts        = "custom-mount"
-	OpDiscoverState       = "discover-state"
-	OpMountState          = "mount-state"
-	OpMountBind           = "mount-bind"
-	OpMountRoot           = "mount-root"
-	OpOverlayMount        = "overlay-mount"
-	OpWriteFstab          = "write-fstab"
-	OpMountBaseOverlay    = "mount-base-overlay"
-	OpMountOEM            = "mount-oem"
-	OpRootfsHook          = "rootfs-hook"
-	OpInitramfsHook       = "initramfs-hook"
-	OpLoadConfig          = "load-config"
-	OpMountTmpfs          = "mount-tmpfs"
-	OpRemountRootRO       = "remount-ro"
-	OpUkiInit             = "uki-init"
-	OpSentinel            = "create-sentinel"
-	OpUkiUdev             = "uki-udev"
-	OpUkiBaseMounts       = "uki-base-mounts"
-	OpUkiKernelModules    = "uki-kernel-modules"
-	OpWaitForSysroot      = "wait-for-sysroot"
-	OpLvmActivate         = "lvm-activation"
-	OpKcryptUnlock        = "unlock-all"
-	OpKcryptUpgrade       = "upgrade-kcrypt"
-	OpUkiKcrypt           = "uki-unlock"
-	OpUkiMountLivecd      = "mount-livecd"
-	UkiLivecdMountPoint   = "/run/initramfs/live"
-	UkiLivecdPath         = "/dev/disk/by-label/UKI_ISO_INSTALL"
-	UkiDefaultcdrom       = "/dev/sr0"
-	UkiDefaultcdromFsType = "iso9660"
-	PersistentStateTarget = "/usr/local/.state"
-	LogDir                = "/run/immucore"
-	LinuxFs               = "ext4"
+	OpCustomMounts         = "custom-mount"
+	OpDiscoverState        = "discover-state"
+	OpMountState           = "mount-state"
+	OpMountBind            = "mount-bind"
+	OpMountRoot            = "mount-root"
+	OpOverlayMount         = "overlay-mount"
+	OpWriteFstab           = "write-fstab"
+	OpMountBaseOverlay     = "mount-base-overlay"
+	OpMountOEM             = "mount-oem"
+	OpRootfsHook           = "rootfs-hook"
+	OpInitramfsHook        = "initramfs-hook"
+	OpLoadConfig           = "load-config"
+	OpMountTmpfs           = "mount-tmpfs"
+	OpRemountRootRO        = "remount-ro"
+	OpUkiInit              = "uki-init"
+	OpSentinel             = "create-sentinel"
+	OpUkiUdev              = "uki-udev"
+	OpUkiBaseMounts        = "uki-base-mounts"
+	OpUkiKernelModules     = "uki-kernel-modules"
+	OpWaitForSysroot       = "wait-for-sysroot"
+	OpLvmActivate          = "lvm-activation"
+	OpKcryptUnlock         = "unlock-all"
+	OpKcryptUpgrade        = "upgrade-kcrypt"
+	OpUkiKcrypt            = "uki-unlock"
+	OpUkiMountLivecd       = "mount-livecd"
+	UkiLivecdMountPoint    = "/run/initramfs/live"
+	UkiIsoBaseTree         = "/run/rootfsbase"
+	UkiIsoBootImage        = "efiboot.img"
+	UkiLivecdPath          = "/dev/disk/by-label/UKI_ISO_INSTALL"
+	UkiDefaultcdrom        = "/dev/sr0"
+	UkiDefaultcdromFsType  = "iso9660"
+	UkiDefaultEfiimgFsType = "vfat"
+	PersistentStateTarget  = "/usr/local/.state"
+	LogDir                 = "/run/immucore"
 )

--- a/pkg/mount/dag_uki_boot.go
+++ b/pkg/mount/dag_uki_boot.go
@@ -24,11 +24,11 @@ func (s *State) RegisterUKI(g *herd.Graph) error {
 	// Mount ESP partition under efi if it exists
 	s.LogIfError(s.MountESPPartition(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev)), "mount ESP partition")
 
-	// Mount cdrom under /run/initramfs/livecd if it exists
+	// Mount cdrom under /run/initramfs/livecd and /run/rootfsbase for the efiboot.img contents
 	s.LogIfError(s.MountLiveCd(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev)), "Mount LiveCD")
 
 	// Run rootfs stage (doesnt this need to be run after mounting OEM???
-	s.LogIfError(s.RootfsStageDagStep(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev)), "uki rootfs")
+	s.LogIfError(s.RootfsStageDagStep(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev), herd.WithWeakDeps(cnst.OpUkiMountLivecd)), "uki rootfs")
 
 	// Remount root RO
 	s.LogIfError(s.UKIRemountRootRODagStep(g), "remount root")


### PR DESCRIPTION
So the actual contents of the cdrom are available under that route, same as non-uki dracdut does.