### PR TITLE
Change the secureboot disable to not collide with disable immucore

### DIFF
--- a/pkg/mount/dag_steps.go
+++ b/pkg/mount/dag_steps.go
@@ -465,7 +465,7 @@ func (s *State) UKIMountBaseSystem(g *herd.Graph) error {
 					}
 				}
 
-				if !efi.GetSecureBoot() && len(internalUtils.ReadCMDLineArg("rd.immucore.disablesecureboot")) == 0 {
+				if !efi.GetSecureBoot() && len(internalUtils.ReadCMDLineArg("rd.immucore.securebootdisabled")) == 0 {
 					internalUtils.Log.Panic().Msg("Secure boot is not enabled")
 				}
 				output, pcrErr := internalUtils.CommandWithPath("/usr/lib/systemd/systemd-pcrphase --graceful enter-initrd")


### PR DESCRIPTION
We were both matching rd.immucore.disable and
rd.immucore.disablesecureboot when trying to check if we want to disable immucore on livecd, which resulted in the wrong path being taken when trying to disable the secureboot check