### PR TITLE
Recover the remount / RO

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -84,7 +84,6 @@ const (
 	OpInitramfsHook        = "initramfs-hook"
 	OpLoadConfig           = "load-config"
 	OpMountTmpfs           = "mount-tmpfs"
-	OpRemountRootRO        = "remount-ro"
 	OpUkiInit              = "uki-init"
 	OpSentinel             = "create-sentinel"
 	OpUkiUdev              = "uki-udev"

--- a/pkg/mount/dag_uki_boot.go
+++ b/pkg/mount/dag_uki_boot.go
@@ -30,13 +30,10 @@ func (s *State) RegisterUKI(g *herd.Graph) error {
 	// Run rootfs stage (doesnt this need to be run after mounting OEM???
 	s.LogIfError(s.RootfsStageDagStep(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev), herd.WithWeakDeps(cnst.OpUkiMountLivecd)), "uki rootfs")
 
-	// Remount root RO
-	s.LogIfError(s.UKIRemountRootRODagStep(g), "remount root")
-
 	// Unlock partitions if needed with TPM
-	s.LogIfError(s.UKIUnlock(g, herd.WithDeps(cnst.OpSentinel, cnst.OpRemountRootRO)), "uki unlock")
+	s.LogIfError(s.UKIUnlock(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev)), "uki unlock")
 
-	s.LogIfError(s.MountOemDagStep(g, herd.WithDeps(cnst.OpRemountRootRO, cnst.OpUkiKcrypt), herd.WeakDeps), "oem mount")
+	s.LogIfError(s.MountOemDagStep(g, herd.WithDeps(cnst.OpUkiKcrypt), herd.WeakDeps), "oem mount")
 
 	// Populate state bind mounts, overlay mounts, custom-mounts from /run/cos/cos-layout.env
 	// Requires stage rootfs to have run, which usually creates the cos-layout.env file


### PR DESCRIPTION
When we did the changes to fix the mounts, the root dir was not remounted as RO.

This brings it back at the end of the dag and drops the not needed step in the middle as we are now pivoting into the fake sysroot