### PR TITLE
fix(mount): call sync before/after operations

### DIFF
--- a/internal/utils/chroot.go
+++ b/internal/utils/chroot.go
@@ -70,9 +70,9 @@ func (c *Chroot) Prepare() error {
 		// For example you can also have a cdrom device mounted under /dev/sr0 or /dev/cdrom and we dont know how to find it and mark it private
 		switch {
 		case mnt == "/sys", mnt == "/dev", mnt == "/run":
-			err = syscall.Mount(mnt, mountPoint, "", syscall.MS_BIND, "")
+			err = Mount(mnt, mountPoint, "", syscall.MS_BIND, "")
 		default:
-			err = syscall.Mount(mnt, mountPoint, "", syscall.MS_BIND|syscall.MS_REC, "")
+			err = Mount(mnt, mountPoint, "", syscall.MS_BIND|syscall.MS_REC, "")
 		}
 
 		if err != nil {
@@ -80,7 +80,7 @@ func (c *Chroot) Prepare() error {
 			return err
 		}
 		// "remount" with private so unmount events do not propagate
-		err = syscall.Mount("", mountPoint, "", syscall.MS_PRIVATE, "")
+		err = Mount("", mountPoint, "", syscall.MS_PRIVATE, "")
 		if err != nil {
 			Log.Err(err).Str("where", mountPoint).Str("what", mnt).Msg("Mounting chroot bind")
 			return err

--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -303,14 +303,14 @@ func ActivateLVM() error {
 	return err
 }
 
-// Force flushing the data to disk
+// Force flushing the data to disk.
 func Sync() {
 	// wrapper isn't necessary, but leaving it here in case
-	// we want to add more logic in the future
+	// we want to add more logic in the future.
 	syscall.Sync()
 }
 
-// Mount will mount the given source to the target with the given fstype and flags
+// Mount will mount the given source to the target with the given fstype and flags.
 func Mount(source string, target string, fstype string, flags uintptr, data string) (err error) {
 	Sync()
 	defer Sync()

--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -201,13 +201,13 @@ func Fsck(device string) error {
 func MountBasic() {
 	_ = os.MkdirAll("/proc", 0755)
 	if !IsMounted("/proc") {
-		_ = syscall.Mount("proc", "/proc", "proc", syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "")
-		_ = syscall.Mount("", "/proc", "", syscall.MS_SHARED, "")
+		_ = Mount("proc", "/proc", "proc", syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "")
+		_ = Mount("", "/proc", "", syscall.MS_SHARED, "")
 	}
 	_ = os.MkdirAll("/run", 0755)
 	if !IsMounted("/run") {
-		_ = syscall.Mount("tmpfs", "/run", "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "mode=755")
-		_ = syscall.Mount("", "/run", "", syscall.MS_SHARED, "")
+		_ = Mount("tmpfs", "/run", "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV|syscall.MS_NOEXEC|syscall.MS_RELATIME, "mode=755")
+		_ = Mount("", "/run", "", syscall.MS_SHARED, "")
 	}
 }
 

--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -302,3 +302,17 @@ func ActivateLVM() error {
 	_, _ = CommandWithPath("udevadm --trigger")
 	return err
 }
+
+// Force flushing the data to disk
+func Sync() {
+	// wrapper isn't necessary, but leaving it here in case
+	// we want to add more logic in the future
+	syscall.Sync()
+}
+
+// Mount will mount the given source to the target with the given fstype and flags
+func Mount(source string, target string, fstype string, flags uintptr, data string) (err error) {
+	Sync()
+	defer Sync()
+	return syscall.Mount(source, target, fstype, flags, data)
+}

--- a/pkg/op/operation.go
+++ b/pkg/op/operation.go
@@ -17,6 +17,9 @@ type MountOperation struct {
 }
 
 func (m MountOperation) Run() error {
+	// call sync to make sure the data is written to disk
+	defer internalUtils.Sync()
+
 	// Add context to sublogger
 	l := internalUtils.Log.With().Str("what", m.MountOption.Source).Str("where", m.Target).Str("type", m.MountOption.Type).Strs("options", m.MountOption.Options).Logger()
 	// Not sure why this defaults to debuglevel when creating a sublogger, so make sure we set it properly

--- a/pkg/state/steps_uki.go
+++ b/pkg/state/steps_uki.go
@@ -452,13 +452,12 @@ func (s *State) UKIMountLiveCd(g *herd.Graph, opts ...herd.OpOption) error {
 
 		// Mount it
 		if cdrom != "" {
-			err = syscall.Mount(cdrom, s.path(cnst.UkiLivecdMountPoint), cnst.UkiDefaultcdromFsType, syscall.MS_RDONLY, "")
+			err = internalUtils.Mount(cdrom, s.path(cnst.UkiLivecdMountPoint), cnst.UkiDefaultcdromFsType, syscall.MS_RDONLY, "")
 			if err != nil {
 				internalUtils.Log.Err(err).Msg(fmt.Sprintf("Mounting %s", cdrom))
 				return err
 			}
 			internalUtils.Log.Debug().Msg(fmt.Sprintf("Mounted %s", cdrom))
-			syscall.Sync()
 
 			// This needs the loop module to be inserted in the kernel!
 			cmd := fmt.Sprintf("losetup --show -f %s", s.path(filepath.Join(cnst.UkiLivecdMountPoint, cnst.UkiIsoBootImage)))
@@ -469,13 +468,12 @@ func (s *State) UKIMountLiveCd(g *herd.Graph, opts ...herd.OpOption) error {
 				internalUtils.Log.Err(err).Str("out", out).Msg(cmd)
 				return err
 			}
-			syscall.Sync()
-			err = syscall.Mount(loop, s.path(cnst.UkiIsoBaseTree), cnst.UkiDefaultEfiimgFsType, syscall.MS_RDONLY, "")
+
+			err = internalUtils.Mount(loop, s.path(cnst.UkiIsoBaseTree), cnst.UkiDefaultEfiimgFsType, syscall.MS_RDONLY, "")
 			if err != nil {
 				internalUtils.Log.Err(err).Msg(fmt.Sprintf("Mounting %s into %s", loop, s.path(cnst.UkiIsoBaseTree)))
 				return err
 			}
-			syscall.Sync()
 			return nil
 		}
 		internalUtils.Log.Debug().Msg("No livecd/install media found")

--- a/pkg/state/steps_uki.go
+++ b/pkg/state/steps_uki.go
@@ -155,7 +155,7 @@ func (s *State) UKIMountBaseSystem(g *herd.Graph) error {
 						internalUtils.Log.Err(e).Msg("Creating dir")
 					}
 
-					e = syscall.Mount(m.what, m.where, m.fs, m.flags, m.data)
+					e = internalUtils.Mount(m.what, m.where, m.fs, m.flags, m.data)
 					if e != nil {
 						err = multierror.Append(err, e)
 						internalUtils.Log.Err(e).Str("what", m.what).Str("where", m.where).Str("type", m.fs).Msg("Mounting")
@@ -191,7 +191,7 @@ func (s *State) UkiPivotToSysroot(g *herd.Graph) error {
 
 			// Mount a tmpfs under sysroot
 			internalUtils.Log.Debug().Msg("Mounting tmpfs on sysroot")
-			err = syscall.Mount("tmpfs", s.path(cnst.UkiSysrootDir), "tmpfs", 0, "")
+			err = internalUtils.Mount("tmpfs", s.path(cnst.UkiSysrootDir), "tmpfs", 0, "")
 			if err != nil {
 				internalUtils.Log.Err(err).Msg("mounting tmpfs on sysroot")
 				internalUtils.DropToEmergencyShell()
@@ -277,7 +277,7 @@ func (s *State) UkiPivotToSysroot(g *herd.Graph) error {
 					}
 				}
 
-				err = syscall.Mount(d, newDir, "", syscall.MS_MOVE, "")
+				err = internalUtils.Mount(d, newDir, "", syscall.MS_MOVE, "")
 				if err != nil {
 					internalUtils.Log.Err(err).Str("what", d).Str("where", newDir).Msg("move mount")
 					continue
@@ -292,7 +292,7 @@ func (s *State) UkiPivotToSysroot(g *herd.Graph) error {
 			}
 
 			internalUtils.Log.Debug().Str("what", s.path(cnst.UkiSysrootDir)).Str("where", "/").Msg("Moving mount")
-			if err = syscall.Mount(s.path(cnst.UkiSysrootDir), "/", "", syscall.MS_MOVE, ""); err != nil {
+			if err = internalUtils.Mount(s.path(cnst.UkiSysrootDir), "/", "", syscall.MS_MOVE, ""); err != nil {
 				internalUtils.Log.Err(err).Msg("mount move")
 				internalUtils.DropToEmergencyShell()
 			}
@@ -500,7 +500,7 @@ func (s *State) UKIBootInitDagStep(g *herd.Graph) error {
 			}
 
 			internalUtils.Log.Debug().Str("what", s.path(s.Rootdir)).Msg("Mount / RO")
-			if err = syscall.Mount("", s.path(s.Rootdir), "", syscall.MS_REMOUNT|syscall.MS_RDONLY, "ro"); err != nil {
+			if err = internalUtils.Mount("", s.path(s.Rootdir), "", syscall.MS_REMOUNT|syscall.MS_RDONLY, "ro"); err != nil {
 				internalUtils.Log.Err(err).Msg("Mount / RO")
 				internalUtils.DropToEmergencyShell()
 			}


### PR DESCRIPTION
This tries to bring more consistency when calling the mounts call and wraps them between `sync` calls - this is just an attempt trying to fix the bug that was reported about missing `sshd` user during boot (not allowing to login remotely on the box). 

The idea behind this is that there is a race condition going on, from the cloud config that quickly tries to add a bunch of users in sequence, and the overlay mount possibly not-ready-yet, or changes just not flushed to the disk yet