### PR TITLE
Fail if dracut cant install required binaries

### DIFF
--- a/dracut/28immucore/module-setup.sh
+++ b/dracut/28immucore/module-setup.sh
@@ -16,16 +16,27 @@ installkernel() {
     instmods overlay
 }
 
+# custom function to check if binaries exist before calling inst_multiple
+inst_check_multiple() {
+    for bin in "$@"; do
+        if ! command -v "$bin" >/dev/null 2>&1; then
+            derror "Required binary $bin not found!"
+            exit 1
+        fi
+    done
+    inst_multiple "$@"
+}
+
+
 # called by dracut
 install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}
     declare systemdsystemunitdir=${systemdsystemunitdir}
 
-    inst_multiple immucore
-    inst_multiple kairos-agent
+    inst_check_multiple immucore kairos-agent
     # add utils used by yip stages
-    inst_multiple partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat blkid lsblk e2fsck resize2fs mount umount sgdisk rsync cryptsetup growpart sfdisk gawk awk
+    inst_check_multiple partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat blkid lsblk e2fsck resize2fs mount umount sgdisk rsync cryptsetup growpart sfdisk gawk awk
 
     # Install libraries needed by gawk
     inst_libdir_file "libsigsegv.so*"

--- a/dracut/28immucore/module-setup.sh
+++ b/dracut/28immucore/module-setup.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 
-# called by dracut
+# check() is called by dracut to evaluate the inclusion of a dracut module in the initramfs.
+# we always want to have this module so we return 0
 check() {
     return 0
 }
 
-# called by dracut 
+# The function depends() should echo all other dracut module names the module depends on
 depends() {
     echo rootfs-block dm fs-lib lvm
     return 0
 }
 
-# called by dracut
+# In installkernel() all kernel related files should be installed
 installkernel() {
     instmods overlay
 }
@@ -28,7 +29,7 @@ inst_check_multiple() {
 }
 
 
-# called by dracut
+# The install() function is called to install everything non-kernel related.
 install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}


### PR DESCRIPTION
Dracut inst_multiple does not fail if it cant find any of the required binaries, thus letting an initrafs in a broken state.

This patch adds a function that will first check for those binaries and fail if it cant find them, then if it can find all of them calls the inst_multiple to install them

Fixes https://github.com/kairos-io/kairos/issues/2692

Manually tested by changing the dockerfile to remove a needed package and running dracut:

```
    RUN apt-get remove -y dosfstools
    COPY module-setup.sh /usr/lib/dracut/modules.d/28immucore/module-setup.sh
    RUN kernel=$(ls /lib/modules | head -n1) && dracut -f "/boot/initrd-${kernel}" "${kernel}"
```

```
         +base-image *failed* | dracut[I]: Module 'memstrack' will not be installed, because command 'memstrack' could not be found!
         +base-image *failed* | dracut[I]: memstrack is not available
         +base-image *failed* | dracut[I]: If you need to use rd.memdebug>=4, please install memstrack and procps-ng
         +base-image *failed* | bash
         +base-image *failed* | systemd
         +base-image *failed* | systemd-initrd
         +base-image *failed* | systemd-networkd
         +base-image *failed* | systemd-sysext
         +base-image *failed* | systemd-sysusers
         +base-image *failed* | modsign
         +base-image *failed* | dbus-daemon
         +base-image *failed* | dbus
         +base-image *failed* | i18n
         +base-image *failed* | immucore
         +base-image *failed* | dracut[E]: mkfs.vfat not found!
```