### PR TITLE
feat: Add TPM kernel module support during uki boot

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -13,6 +13,12 @@ func GetCloudInitPaths() []string {
 	return []string{"/system/oem", "/oem/", "/usr/local/cloud-config/"}
 }
 
+func TPMKernelModules() []string {
+	return []string{
+		"tpm_ftpm_tee",
+	}
+}
+
 // GenericKernelDrivers returns a list of generic kernel drivers to insmod during uki mode
 // as they could be useful for a lot of situations.
 func GenericKernelDrivers() []string {
@@ -98,6 +104,7 @@ const (
 	OpUkiUdev              = "uki-udev"
 	OpUkiBaseMounts        = "uki-base-mounts"
 	OpUkiPivotToSysroot    = "uki-pivot-to-sysroot"
+	OpUkiTPMKernelModules  = "uki-tpm-modules"
 	OpUkiKernelModules     = "uki-kernel-modules"
 	OpUkiNetwork           = "uki-network"
 	OpWaitForSysroot       = "wait-for-sysroot"

--- a/pkg/dag/dag_uki_boot.go
+++ b/pkg/dag/dag_uki_boot.go
@@ -15,15 +15,16 @@ func RegisterUKI(s *state.State, g *herd.Graph) error {
 	// Mount basic mounts
 	s.LogIfError(s.UKIMountBaseSystem(g), "mounting base mounts")
 
+	// Load needed kernel TPM modules !
+	s.LogIfError(s.UKILoadTPMModules(g), "kernel TPM modules")
+
 	// Move to sysroot
 	s.LogIfError(s.UkiPivotToSysroot(g), "pivot to sysroot")
 
 	// Write sentinel
 	s.LogIfError(s.WriteSentinelDagStep(g, cnst.OpUkiBaseMounts), "sentinel")
 
-	// Load needed kernel modules
-	// TODO: This seems to be wrong as it leans on the udev to infer the modules, but at this point we dont have udev
-	// So we dont get all the proper modules needed!
+	// Load needed kernel modules !
 	s.LogIfError(s.UKILoadKernelModules(g), "kernel modules")
 
 	// Udev for devices discovery

--- a/pkg/state/steps_shared.go
+++ b/pkg/state/steps_shared.go
@@ -29,7 +29,7 @@ func (s *State) WriteSentinelDagStep(g *herd.Graph, deps ...string) error {
 		herd.WithCallback(func(_ context.Context) error {
 			var sentinel string
 
-			internalUtils.KLog.Logger.Debug().Msg("Will now create /run/cos is not exists")
+			internalUtils.KLog.Logger.Debug().Msg("Will now create /run/cos if not exists")
 			err := internalUtils.CreateIfNotExists("/run/cos/")
 			if err != nil {
 				internalUtils.KLog.Logger.Err(err).Msg("failed to create /run/cos")

--- a/pkg/state/steps_uki.go
+++ b/pkg/state/steps_uki.go
@@ -170,7 +170,7 @@ func (s *State) UKIMountBaseSystem(g *herd.Graph) error {
 // And moving all the mounts into it and all the files as well.
 func (s *State) UkiPivotToSysroot(g *herd.Graph) error {
 	return g.Add(cnst.OpUkiPivotToSysroot,
-		herd.WithDeps(cnst.OpUkiBaseMounts),
+		herd.WithDeps(cnst.OpUkiBaseMounts, cnst.OpUkiTPMKernelModules),
 		herd.WithCallback(func(_ context.Context) error {
 			var err error
 			// Create the new sysroot and move to it
@@ -302,16 +302,16 @@ func (s *State) UkiPivotToSysroot(g *herd.Graph) error {
 				internalUtils.KLog.Logger.Err(pcrErr).Str("ext", ext).Msg("extend-pcr")
 			}
 
-			pcrErr = os.MkdirAll("/run/systemd", 0755) // #nosec G301 -- Original dir has this permissions
-			if pcrErr != nil {
-				internalUtils.KLog.Logger.Err(pcrErr).Msg("Creating /run/systemd dir")
+			err = os.MkdirAll("/run/systemd", 0755) // #nosec G301 -- Original dir has this permissions
+			if err != nil {
+				internalUtils.KLog.Logger.Err(err).Msg("Creating /run/systemd dir")
 			}
 			// This dir is created by systemd-stub and passed to the kernel as a cpio archive
 			// that gets mounted in the initial ramdisk where we run immucore from
 			// It contains the tpm public key and signatures of the current uki
-			out, pcrErr := internalUtils.CommandWithPath("cp -r /.extra/* /run/systemd/")
-			if pcrErr != nil {
-				internalUtils.KLog.Logger.Err(pcrErr).Str("out", out).Msg("Copying extra files")
+			out, err := internalUtils.CommandWithPath("cp -r /.extra/* /run/systemd/")
+			if err != nil {
+				internalUtils.KLog.Logger.Err(err).Str("out", out).Msg("Copying extra files")
 			}
 			return err
 		}))
@@ -353,12 +353,34 @@ func (s *State) UKIUdevDaemon(g *herd.Graph) error {
 	)
 }
 
+// UKILoadTPMModules loads kernel modules needed for TPM support during uki boot.
+// We need to load them ASAP as our measurement depends on this.
+func (s *State) UKILoadTPMModules(g *herd.Graph) error {
+	return g.Add(cnst.OpUkiTPMKernelModules,
+		herd.WithDeps(cnst.OpUkiBaseMounts),
+		herd.WithCallback(func(_ context.Context) error {
+			// Run depmod to ensure all modules are loaded and modules.dep updated
+			_, _ = internalUtils.CommandWithPath("depmod -a")
+			drivers := cnst.TPMKernelModules()
+			internalUtils.KLog.Logger.Debug().Strs("drivers", drivers).Msg("Detecting needed modules")
+			for _, driver := range drivers {
+				cmd := fmt.Sprintf("modprobe %s", driver)
+				out, err := internalUtils.CommandWithPath(cmd)
+				if err != nil {
+					internalUtils.KLog.Logger.Debug().Err(err).Str("out", out).Msg("modprobe")
+				}
+			}
+			return nil
+		}),
+	)
+}
+
 // UKILoadKernelModules loads kernel modules needed during uki boot to load the disks for.
 // Mainly block devices and net devices
 // probably others down the line.
 func (s *State) UKILoadKernelModules(g *herd.Graph) error {
 	return g.Add(cnst.OpUkiKernelModules,
-		herd.WithDeps(cnst.OpUkiBaseMounts, cnst.OpUkiPivotToSysroot),
+		herd.WithDeps(cnst.OpUkiBaseMounts, cnst.OpUkiPivotToSysroot, cnst.OpUkiTPMKernelModules),
 		herd.WithCallback(func(_ context.Context) error {
 			// Run depmod to ensure all modules are loaded and modules.dep updated
 			_, _ = internalUtils.CommandWithPath("depmod -a")


### PR DESCRIPTION
- Introduced `TPMKernelModules` function to return necessary TPM kernel modules.
- Added `UKILoadTPMModules` method to load TPM modules early in the boot process.
- Updated dependencies in `UkiPivotToSysroot` and `UKILoadKernelModules` to include TPM module loading.
- Improved logging for module loading errors to enhance debugging capabilities.



This makes sure that we load TPM modules ASAP as when we pivot into sysroot we need to extend the PCR and for that we need the tpm device to be available