### PR TITLE
Potential fix for code scanning alert no. 188: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-unit-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/immucore/security/code-scanning/188](https://github.com/kairos-io/immucore/security/code-scanning/188)

Add an explicit `permissions` block to `.github/workflows/unit-tests.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This supports `actions/checkout` and typical read-only operations used by unit tests. No new imports, methods, or definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
