### PR TITLE
Potential fix for code scanning alert no. 187: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secscan.yaml
+++ b/.github/workflows/secscan.yaml
@@ -10,6 +10,10 @@ on:
   schedule:
   - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/immucore/security/code-scanning/187](https://github.com/kairos-io/immucore/security/code-scanning/187)

Add an explicit `permissions` block at the workflow root (or job level). Best here is workflow-root permissions because there is only one job and it keeps configuration simple.

For this workflow:
- `actions/checkout` requires `contents: read`.
- `upload-sarif` requires `security-events: write`.

So insert under the `on:` section (before `jobs:`) a minimal explicit block:

- `contents: read`
- `security-events: write`

File to change: `.github/workflows/secscan.yaml`  
Region: between existing lines 11 and 13 (after schedule, before jobs).  
No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
