### PR TITLE
Potential fix for code scanning alert no. 186: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/immucore/security/code-scanning/186](https://github.com/kairos-io/immucore/security/code-scanning/186)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` scopes are documented and constrained.  
Best fix here (without changing intended functionality) is to set permissions at the workflow root, since there is only one job and it performs release publishing via GoReleaser. That requires at least `contents: write` to create/update GitHub Releases and upload assets.  

**File to change:** `.github/workflows/release.yaml`  
**Region:** after the `on:` trigger block and before `jobs:`.  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
