### PR TITLE
fix(mounts): modify vgchange command to avoid refresh

### DIFF
--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -319,12 +319,12 @@ func ActivateLVM() error {
 
 	// Activate (do NOT refresh) all available volume groups in system-init mode.
 	// We only need inactive boot volumes brought up (COS_* partitions on LVM installs);
-	// -ay is a no-op on already-active LVs. --refresh must be avoided: it suspends and
+	// --activate y is a no-op on already-active LVs. --refresh must be avoided: it suspends and
 	// reloads every active LV, including unrelated data VGs that event-based
 	// autoactivation already brought up (e.g. kubernetes pvc volumes). That reload can
 	// fail mid-operation and leave a device suspended (vgchange exit 5), which then
 	// poisons the strong-dep boot DAG (oem mount + kcrypt depend on this step).
-	out, err := CommandWithPath("lvm vgchange -ay --sysinit")
+	out, err := CommandWithPath("lvm vgchange --activate y --sysinit")
 	KLog.Logger.Debug().Str("out", out).Msg("vgchange")
 	if err != nil {
 		KLog.Logger.Err(err).Msg("vgchange")

--- a/internal/utils/mounts.go
+++ b/internal/utils/mounts.go
@@ -316,7 +316,15 @@ func ActivateLVM() error {
 	// Otherwise, it has a default locking setting which activates the volumes on readonly
 	// This would be the same as passing rd.lvm.conf=0 in cmdline but rather do it here than add an extra option to cmdline
 	_, _ = CommandWithPath("rm /etc/lvm/lvm.conf")
-	out, err := CommandWithPath("lvm vgchange --refresh --sysinit")
+
+	// Activate (do NOT refresh) all available volume groups in system-init mode.
+	// We only need inactive boot volumes brought up (COS_* partitions on LVM installs);
+	// -ay is a no-op on already-active LVs. --refresh must be avoided: it suspends and
+	// reloads every active LV, including unrelated data VGs that event-based
+	// autoactivation already brought up (e.g. kubernetes pvc volumes). That reload can
+	// fail mid-operation and leave a device suspended (vgchange exit 5), which then
+	// poisons the strong-dep boot DAG (oem mount + kcrypt depend on this step).
+	out, err := CommandWithPath("lvm vgchange -ay --sysinit")
 	KLog.Logger.Debug().Str("out", out).Msg("vgchange")
 	if err != nil {
 		KLog.Logger.Err(err).Msg("vgchange")


### PR DESCRIPTION
- Changed the vgchange command from `--refresh` to `-ay` to activate only inactive boot volumes during system initialization.
- This prevents potential failures caused by reloading active logical volumes, which can disrupt the boot process.