### PR TITLE
fix(uki): pin sysroot tmpfs to mode 0755

### DIFF
--- a/pkg/state/steps_uki.go
+++ b/pkg/state/steps_uki.go
@@ -184,7 +184,11 @@ func (s *State) UkiPivotToSysroot(g *herd.Graph) error {
 
 			// Mount a tmpfs under sysroot
 			internalUtils.KLog.Logger.Debug().Msg("Mounting tmpfs on sysroot")
-			err = internalUtils.Mount("tmpfs", s.path(cnst.UkiSysrootDir), "tmpfs", 0, "")
+			// Pin the tmpfs root to 0755 explicitly. Without mode= the kernel uses
+			// 0777 & ~umask, which is non-deterministic in early boot and can leave / as
+			// 0777. Normal (non-UKI) boot mounts a real image fs whose root is 0755, so
+			// match that. Some software (e.g. snapd) requires / to be 0755.
+			err = internalUtils.Mount("tmpfs", s.path(cnst.UkiSysrootDir), "tmpfs", 0, "mode=0755")
 			if err != nil {
 				internalUtils.KLog.Logger.Err(err).Msg("mounting tmpfs on sysroot")
 				internalUtils.DropToEmergencyShell()


### PR DESCRIPTION
The UKI boot path mounts a tmpfs at /sysroot which becomes the final root after MS_MOVE + chroot. It was mounted without a mode= option, so the kernel fell back to 0777 & ~umask. In early boot the umask is not guaranteed, which can leave / as 0777 instead of 0755.

Normal (non-UKI) boot mounts a real image filesystem whose root is 0755, so UKI should match. Some software (e.g. snapd) requires / to be 0755 and breaks otherwise.

Fixes https://github.com/kairos-io/kairos/issues/4182