### PR TITLE
refactor: delegate kernel cmdline parsing to kairos-sdk

### DIFF
--- a/internal/utils/cloudinit.go
+++ b/internal/utils/cloudinit.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/kairos-io/immucore/internal/constants"
+	"github.com/kairos-io/kairos-sdk/machine"
 	"github.com/mudler/yip/pkg/console"
 	"github.com/mudler/yip/pkg/executor"
-	"github.com/mudler/yip/pkg/schema"
 	"github.com/twpayne/go-vfs/v4"
 	"gopkg.in/yaml.v3"
 )
 
 func RunStage(stage string) error {
 	var allErrors, err error
-	var cmdLineYipURI string
 
 	// Set debug logger
 	yip := executor.NewExecutor(executor.WithLogger(KLog))
@@ -24,11 +23,6 @@ func RunStage(stage string) error {
 
 	stageBefore := fmt.Sprintf("%s.before", stage)
 	stageAfter := fmt.Sprintf("%s.after", stage)
-	// Deprecated? Is nowhere on the docs....
-	cosSetup := ReadCMDLineArg("cos.setup")
-	if len(cosSetup) > 1 {
-		cmdLineYipURI = cosSetup[1]
-	}
 
 	// Run all stages for each of the default cloud config paths + extra cloud config paths
 	for _, s := range []string{stageBefore, stage, stageAfter} {
@@ -38,24 +32,26 @@ func RunStage(stage string) error {
 		}
 	}
 
-	// Run the stages if cmdline contains the cos.setup stanza
-	if cmdLineYipURI != "" {
-		cmdLineArgs := []string{cmdLineYipURI}
+	// Kairos-owned cmdline stanzas (kairos.config_url= and legacy bare cos.setup=)
+	// resolve to a config source URI which we hand to yip as an additional stage source.
+	// Parsing is delegated to kairos-sdk/machine so immucore, kairos-agent and any other
+	// consumer stay in lockstep. See kairos-sdk PR #812.
+	if uri := KairosConfigURIFromCmdline(); uri != "" {
 		for _, s := range []string{stageBefore, stage, stageAfter} {
-			err = yip.Run(s, vfs.OSFS, c, cmdLineArgs...)
+			err = yip.Run(s, vfs.OSFS, c, uri)
 			if err != nil {
 				allErrors = multierror.Append(allErrors, err)
 			}
 		}
 	}
 
-	// Enable dot notation
-	// This helps to parse the cmdline in dot notation (stage.name.command) from cmdline
-	// IMHO this should be deprecated, plenty of other places to set the stages config
-	yip.Modifier(schema.DotNotationModifier)
+	// Enable dot notation via the SDK parser so that arbitrary dot-nested cmdline tokens
+	// (e.g. stages.initramfs[0].name=foo) become yip stages, while Kairos-owned prefixes
+	// (kairos.config=, kairos.config_url=, cos.setup=) are skipped and handled above.
+	yip.Modifier(SDKDotNotationModifier)
 
 	// Read and parse the cmdline looking for yip config in there
-	cmdLineOut, err := os.ReadFile("/proc/cmdline")
+	cmdLineOut, err := os.ReadFile(GetHostProcCmdline())
 	if err == nil {
 		for _, s := range []string{stageBefore, stage, stageAfter} {
 			err = yip.Run(s, vfs.OSFS, console.NewStandardConsole(), string(cmdLineOut))
@@ -70,6 +66,45 @@ func RunStage(stage string) error {
 
 	// Not doing anything with the errors yet, need to know which ones are permissible (no metadata, marshall errors, etc..)
 	return nil
+}
+
+// KairosConfigURIFromCmdline reads the kernel cmdline (via GetHostProcCmdline so tests
+// can mock it) and returns the config source URI extracted from any Kairos-owned stanza
+// (kairos.config_url=URI or legacy bare cos.setup=URI). Returns empty when no such stanza
+// is present or when the parsed YAML contains only nested key=value payloads (which are
+// consumed by kairos-agent, not immucore). Parsing goes through kairos-sdk/machine so
+// immucore stays consistent with kairos-agent's config collector.
+func KairosConfigURIFromCmdline() string {
+	dat, err := os.ReadFile(GetHostProcCmdline())
+	if err != nil {
+		return ""
+	}
+	return KairosConfigURIFromString(string(dat))
+}
+
+// KairosConfigURIFromString is the string-based counterpart of KairosConfigURIFromCmdline.
+// Exposed so tests can exercise every cmdline variant without touching the filesystem.
+func KairosConfigURIFromString(s string) string {
+	yml, err := machine.KairosCmdlineYAMLFromString(s)
+	if err != nil || len(yml) == 0 {
+		return ""
+	}
+	var m map[string]interface{}
+	if err := yaml.Unmarshal(yml, &m); err != nil {
+		return ""
+	}
+	if v, ok := m["config_url"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// SDKDotNotationModifier converts dot-nested KEY=VALUE cmdline tokens into YAML via
+// kairos-sdk/machine. Unlike yip's built-in schema.DotNotationModifier it skips
+// Kairos-owned prefixes (kairos.config=, kairos.config_url=, cos.setup=) so those
+// tokens are not double-processed here — they flow through KairosConfigURIFromCmdline.
+func SDKDotNotationModifier(s []byte) ([]byte, error) {
+	return machine.DotStringToYAML(string(s))
 }
 
 func onlyYAMLPartialErrors(er error) bool {

--- a/internal/utils/cloudinit_test.go
+++ b/internal/utils/cloudinit_test.go
@@ -56,6 +56,10 @@ var _ = Describe("Kairos cmdline parsing (kairos-sdk integration)", func() {
 			Expect(utils.KairosConfigURIFromCmdline()).To(Equal(""))
 		})
 		It("respects HOST_PROC_CMDLINE and returns empty on missing cmdline file", func() {
+			path, err := fs.RawPath("/proc/cmdline")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(os.Setenv("HOST_PROC_CMDLINE", path)).To(Succeed())
+
 			writeCmdline("root=LABEL=X kairos.config_url=https://example.com/from-env.yaml quiet")
 			Expect(utils.KairosConfigURIFromCmdline()).To(Equal("https://example.com/from-env.yaml"))
 

--- a/internal/utils/cloudinit_test.go
+++ b/internal/utils/cloudinit_test.go
@@ -24,8 +24,11 @@ var _ = Describe("Kairos cmdline parsing (kairos-sdk integration)", func() {
 	}
 
 	BeforeEach(func() {
-		fs, cleanup, _ = vfst.NewTestFS(map[string]interface{}{"/proc/cmdline": ""})
-		path, _ := fs.RawPath("/proc/cmdline")
+		var err error
+		fs, cleanup, err = vfst.NewTestFS(map[string]interface{}{ "/proc/cmdline": "" })
+		Expect(err).ToNot(HaveOccurred())
+		path, err := fs.RawPath("/proc/cmdline")
+		Expect(err).ToNot(HaveOccurred())
 		Expect(os.Setenv("HOST_PROC_CMDLINE", path)).To(Succeed())
 	})
 	AfterEach(func() {

--- a/internal/utils/cloudinit_test.go
+++ b/internal/utils/cloudinit_test.go
@@ -55,7 +55,10 @@ var _ = Describe("Kairos cmdline parsing (kairos-sdk integration)", func() {
 			writeCmdline("root=LABEL=X rd.immucore.debug quiet console=ttyS0")
 			Expect(utils.KairosConfigURIFromCmdline()).To(Equal(""))
 		})
-		It("returns empty on missing cmdline file", func() {
+		It("respects HOST_PROC_CMDLINE and returns empty on missing cmdline file", func() {
+			writeCmdline("root=LABEL=X kairos.config_url=https://example.com/from-env.yaml quiet")
+			Expect(utils.KairosConfigURIFromCmdline()).To(Equal("https://example.com/from-env.yaml"))
+
 			Expect(os.Setenv("HOST_PROC_CMDLINE", "/definitely/not/a/real/path/proc/cmdline")).To(Succeed())
 			Expect(utils.KairosConfigURIFromCmdline()).To(Equal(""))
 		})

--- a/internal/utils/cloudinit_test.go
+++ b/internal/utils/cloudinit_test.go
@@ -1,0 +1,127 @@
+package utils_test
+
+import (
+	"os"
+
+	"github.com/kairos-io/immucore/internal/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/twpayne/go-vfs/v4"
+	"github.com/twpayne/go-vfs/v4/vfst"
+	"gopkg.in/yaml.v3"
+)
+
+// These specs exercise the cmdline-parsing helpers that immucore inherits from
+// kairos-sdk (PR #812). The goal is to guarantee immucore stays wired to the
+// SDK parser so the modern kairos.config= / kairos.config_url= stanzas and the
+// legacy cos.setup= alias all resolve consistently.
+var _ = Describe("Kairos cmdline parsing (kairos-sdk integration)", func() {
+	var fs vfs.FS
+	var cleanup func()
+
+	writeCmdline := func(s string) {
+		Expect(fs.WriteFile("/proc/cmdline", []byte(s), os.ModePerm)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		fs, cleanup, _ = vfst.NewTestFS(map[string]interface{}{"/proc/cmdline": ""})
+		path, _ := fs.RawPath("/proc/cmdline")
+		Expect(os.Setenv("HOST_PROC_CMDLINE", path)).To(Succeed())
+	})
+	AfterEach(func() {
+		_ = os.Unsetenv("HOST_PROC_CMDLINE")
+		cleanup()
+	})
+
+	Context("KairosConfigURIFromCmdline (file-backed)", func() {
+		It("extracts URI from kairos.config_url=", func() {
+			writeCmdline("root=LABEL=X kairos.config_url=https://example.com/cfg.yaml quiet")
+			Expect(utils.KairosConfigURIFromCmdline()).To(Equal("https://example.com/cfg.yaml"))
+		})
+		It("extracts URI from legacy bare cos.setup=", func() {
+			writeCmdline("root=LABEL=X cos.setup=https://example.com/legacy.yaml quiet")
+			Expect(utils.KairosConfigURIFromCmdline()).To(Equal("https://example.com/legacy.yaml"))
+		})
+		It("returns empty when only nested kairos.config= stanzas are present", func() {
+			// kairos.config=key=value is consumed by kairos-agent, not immucore, so
+			// there is no yip source URI to hand off — expect empty.
+			writeCmdline("kairos.config=install.auto=true kairos.config=users.0.name=kairos")
+			Expect(utils.KairosConfigURIFromCmdline()).To(Equal(""))
+		})
+		It("returns empty when cmdline contains no Kairos-owned stanzas", func() {
+			writeCmdline("root=LABEL=X rd.immucore.debug quiet console=ttyS0")
+			Expect(utils.KairosConfigURIFromCmdline()).To(Equal(""))
+		})
+		It("returns empty on missing cmdline file", func() {
+			Expect(os.Setenv("HOST_PROC_CMDLINE", "/definitely/not/a/real/path/proc/cmdline")).To(Succeed())
+			Expect(utils.KairosConfigURIFromCmdline()).To(Equal(""))
+		})
+	})
+
+	Context("KairosConfigURIFromString (all variants)", func() {
+		DescribeTable("resolves the config URI",
+			func(cmdline, expected string) {
+				Expect(utils.KairosConfigURIFromString(cmdline)).To(Equal(expected))
+			},
+			Entry("modern kairos.config_url=URL",
+				"kairos.config_url=https://x.example/cfg.yaml", "https://x.example/cfg.yaml"),
+			Entry("legacy bare cos.setup=URL",
+				"cos.setup=https://x.example/legacy.yaml", "https://x.example/legacy.yaml"),
+			Entry("legacy bare cos.setup=file path",
+				"cos.setup=/oem/99_custom.yaml", "/oem/99_custom.yaml"),
+			Entry("cos.setup= with key=value routes into nested config, not URI",
+				"cos.setup=install.auto=true", ""),
+			Entry("kairos.config_url wins on collision with cos.setup",
+				// Later occurrence wins per SDK contract; kairos.config_url and
+				// bare cos.setup both write to config_url so order matters.
+				"cos.setup=/first.yaml kairos.config_url=/second.yaml", "/second.yaml"),
+			Entry("multiple cos.setup= — last one wins",
+				"cos.setup=/first.yaml cos.setup=/second.yaml", "/second.yaml"),
+			Entry("quoted URL with spaces",
+				`kairos.config_url="https://x.example/path with space.yaml"`, "https://x.example/path with space.yaml"),
+			Entry("empty payload is ignored",
+				"kairos.config_url= root=LABEL=X", ""),
+			Entry("no Kairos-owned tokens",
+				"root=LABEL=X rd.immucore.debug console=ttyS0", ""),
+			Entry("kairos.config=key=value alone yields no URI",
+				"kairos.config=install.auto=true kairos.config=users.0.name=kairos", ""),
+			Entry("mix of nested kairos.config= and kairos.config_url= — URI still resolved",
+				"kairos.config=install.auto=true kairos.config_url=https://x.example/cfg.yaml",
+				"https://x.example/cfg.yaml"),
+		)
+	})
+
+	Context("SDKDotNotationModifier", func() {
+		It("converts generic dot-nested tokens to YAML", func() {
+			out, err := utils.SDKDotNotationModifier([]byte("foo.bar=baz nested.deep.key=1"))
+			Expect(err).ToNot(HaveOccurred())
+			var m map[string]interface{}
+			Expect(yaml.Unmarshal(out, &m)).To(Succeed())
+			Expect(m).To(HaveKey("foo"))
+			Expect(m["foo"]).To(HaveKeyWithValue("bar", "baz"))
+			Expect(m).To(HaveKey("nested"))
+		})
+		It("skips Kairos-owned prefixes so they are not double-processed", func() {
+			// The whole point of routing through the SDK: kairos.config=,
+			// kairos.config_url= and cos.setup= are handled elsewhere and MUST
+			// NOT leak into the generic dot-nested output as spurious top-level
+			// keys.
+			out, err := utils.SDKDotNotationModifier([]byte(
+				"foo.bar=baz kairos.config=install.auto=true kairos.config_url=http://x/y cos.setup=/z",
+			))
+			Expect(err).ToNot(HaveOccurred())
+			var m map[string]interface{}
+			Expect(yaml.Unmarshal(out, &m)).To(Succeed())
+			Expect(m).To(HaveKey("foo"))
+			Expect(m).ToNot(HaveKey("kairos"))
+			Expect(m).ToNot(HaveKey("cos"))
+			Expect(m).ToNot(HaveKey("config_url"))
+		})
+		It("returns valid YAML for empty input", func() {
+			out, err := utils.SDKDotNotationModifier([]byte(""))
+			Expect(err).ToNot(HaveOccurred())
+			var m map[string]interface{}
+			Expect(yaml.Unmarshal(out, &m)).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
RunStage was doing its own cmdline handling with ReadCMDLineArg("cos.setup") and yip's schema.DotNotationModifier, which meant every config source variant (modern kairos.config_url=, nested kairos.config=key=value, legacy bare cos.setup=) had to be reimplemented here and kept in sync with the SDK.

Move all of it behind kairos-sdk v0.24.0 (see kairos-sdk#812):

- Add KairosConfigURIFromCmdline / KairosConfigURIFromString wrapping machine.KairosCmdlineYAMLFromString to resolve the config URI across every supported form
- Add SDKDotNotationModifier backed by machine.DotStringToYAML so Kairos-owned prefixes (kairos.config=, kairos.config_url=, cos.setup=) are skipped and never double-processed by yip
- Swap the hardcoded /proc/cmdline read for GetHostProcCmdline() so tests can mock it

Also add cloudinit_test.go with 19 specs covering every cmdline variant: kairos.config_url=URL, legacy bare cos.setup=URL and file paths, cos.setup=key=value routing to nested (no URI), kairos.config=key=value alone, collision + last-wins ordering, quoted URLs with spaces, empty payloads, missing cmdline file, no Kairos-owned tokens, and that the modifier really does skip the reserved prefixes.