### PR TITLE
feat: support in-RAM boot under trusted boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,26 @@ is the current install), so `/run/cos/active_mode` is written as usual, plus
 an additional `/run/cos/in_ram_mode` sentinel for tooling that needs to know
 the rootfs lives in a tmpfs.
 
+#### Trusted boot (UKI)
+
+The same `kairos.ram.*` stanzas work under trusted boot. A UKI already runs
+entirely from RAM, so the regular UKI flow applies with three differences:
+
+* `create_partitions` encrypts the partitions it creates with the TPM PCR
+  policy (same `systemd-cryptenroll` enrollment kairos-agent performs on a
+  trusted-boot install), so every later boot unlocks them via TPM. There is
+  no plaintext fallback: if encryption fails the boot halts with a
+  full-screen message. Remote KMS (kcrypt-challenger) is not supported here —
+  the UKI initramfs has no network at unlock time.
+* Partition unlock runs even though the UKI was booted from removable or
+  network media (a regular UKI boot skips it in that case).
+* The UKI sentinel is `/run/cos/uki_boot_mode`, not `uki_install_mode`, so
+  installer cloud-init stages do not fire.
+
+Since the cmdline is part of the signed UKI (or a signed addon), the
+`kairos.ram.*` stanzas must be baked in at image build time — they cannot be
+edited interactively at boot.
+
 
 ### Configuration with an environment file
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Since the cmdline is part of the signed UKI (or a signed addon), the
 `kairos.ram.*` stanzas must be baked in at image build time — they cannot be
 edited interactively at boot.
 
+Because the sentinel is `uki_boot_mode`, the stock datasource cloud-config
+skips pulling providers (NoCloud/cidata etc.) — on an installed UKI system
+the config was baked into OEM at install time, but an in-RAM boot has no
+install. To feed per-machine config through a datasource instead of the OEM
+partition, also bake `kairos.pull_datasources` into the cmdline.
+
 
 ### Configuration with an environment file
 

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -477,6 +477,27 @@ func IsUKI() bool {
 	return state.DetectUKIboot(string(cmdline))
 }
 
+// UkiSentinel returns the UKI sentinel name for the current boot. Booting
+// from an installed system always means boot mode. Removable-media boots are
+// install media by default — except under the in-RAM workflow, where the UKI
+// is PXE/ISO-served on purpose and the system must behave like an installed
+// Active one (installer cloud-init stages key off uki_install_mode and must
+// NOT fire).
+func UkiSentinel(bootedFromInstall, inRAM bool) string {
+	if bootedFromInstall || inRAM {
+		return "uki_boot_mode"
+	}
+	return "uki_install_mode"
+}
+
+// SkipUKIUnlock decides whether the UKI unlock step should skip unlocking
+// partitions. Removable-media boots normally have nothing to unlock — but the
+// in-RAM workflow boots from removable/network media by design and still owns
+// encrypted OEM/persistent partitions on disk.
+func SkipUKIUnlock(bootedFromInstall, inRAM bool) bool {
+	return !bootedFromInstall && !inRAM
+}
+
 // BootInRAM returns true when the kernel cmdline enables the in-RAM workflow
 // (kairos.ram token). Wraps kairos-sdk's DetectInRAM and honors the
 // HOST_PROC_CMDLINE seam so tests can drive it. Used only for dispatch in

--- a/internal/utils/partitions.go
+++ b/internal/utils/partitions.go
@@ -431,6 +431,46 @@ func RenderDiskNotFoundMessage(disk string, candidates []string) string {
 	)
 }
 
+// PartitionsToEncrypt maps the pre-creation presence flags to the list of
+// labels the ensure-partitions step just created — under trusted boot (UKI)
+// exactly those must be encrypted with the TPM policy. Partitions that
+// already existed are left alone: they either carry LUKS from a previous
+// boot or were deliberately created plain by another workflow.
+func PartitionsToEncrypt(oemFound, persistentFound bool) []string {
+	var labels []string
+	if !oemFound {
+		labels = append(labels, sdkConstants.OEMLabel)
+	}
+	if !persistentFound {
+		labels = append(labels, sdkConstants.PersistentLabel)
+	}
+	return labels
+}
+
+// RenderEncryptionFailedMessage explains that a freshly created partition
+// could not be encrypted with the TPM PCR policy under trusted boot. The
+// partition table may be partially initialized at this point, so the fix
+// section points at the TPM prerequisites and at wiping the disk to retry.
+func RenderEncryptionFailedMessage(label string, failErr error) string {
+	var wrong strings.Builder
+	fmt.Fprintf(&wrong, "Encrypting the freshly created %s partition with the TPM\n", label)
+	wrong.WriteString("policy failed:\n")
+	fmt.Fprintf(&wrong, "  %s\n", failErr)
+
+	var fix strings.Builder
+	fix.WriteString("  - Check this machine has a working TPM 2.0 device\n")
+	fix.WriteString("  - Inspect the immucore logs on the next boot for the full error\n")
+	fmt.Fprintf(&fix, "  - The disk may hold a half-encrypted partition now; add %s\n", constants.CmdlineAutoCreatePartitionsWipe)
+	fix.WriteString("    to wipe it and retry from scratch\n")
+
+	return RenderFailureScreen(
+		"RAM mode: partition encryption failed",
+		ramModeIntro(),
+		FailureSection{Title: SectionWhatWentWrong, Body: wrong.String()},
+		FailureSection{Title: SectionHowToFix, Body: fix.String()},
+	)
+}
+
 // RenderWipeRequiredMessage explains that the target disk already has a
 // partition table and the wipe flag is not set. Same reasoning as
 // RenderAmbiguousDiskMessage — halt loudly over overwriting data.

--- a/internal/utils/partitions_test.go
+++ b/internal/utils/partitions_test.go
@@ -183,5 +183,46 @@ var _ = Describe("ensure-partitions helpers", func() {
 			Expect(out).To(ContainSubstring("kairos.ram.wipe"))
 			Expect(out).To(ContainSubstring("DESTROYS"))
 		})
+		It("Encryption-failed message names the partition, TPM and the underlying error", func() {
+			out := utils.RenderEncryptionFailedMessage("COS_PERSISTENT", errors.New("tpm2-cryptenroll exploded"))
+			Expect(out).To(ContainSubstring("KAIROS BOOT FAILED"))
+			Expect(out).To(ContainSubstring("COS_PERSISTENT"))
+			Expect(out).To(ContainSubstring("TPM"))
+			Expect(out).To(ContainSubstring("tpm2-cryptenroll exploded"))
+		})
+	})
+
+	Context("PartitionsToEncrypt", func() {
+		It("returns both labels when both partitions were created", func() {
+			Expect(utils.PartitionsToEncrypt(false, false)).To(Equal([]string{"COS_OEM", "COS_PERSISTENT"}))
+		})
+		It("returns only the created sibling when OEM already existed", func() {
+			Expect(utils.PartitionsToEncrypt(true, false)).To(Equal([]string{"COS_PERSISTENT"}))
+		})
+		It("returns only the created sibling when persistent already existed", func() {
+			Expect(utils.PartitionsToEncrypt(false, true)).To(Equal([]string{"COS_OEM"}))
+		})
+		It("returns nothing when both partitions already existed", func() {
+			Expect(utils.PartitionsToEncrypt(true, true)).To(BeEmpty())
+		})
+	})
+
+	Context("UKI in-RAM helpers", func() {
+		It("UkiSentinel is boot mode when booted from an install", func() {
+			Expect(utils.UkiSentinel(true, false)).To(Equal("uki_boot_mode"))
+			Expect(utils.UkiSentinel(true, true)).To(Equal("uki_boot_mode"))
+		})
+		It("UkiSentinel is install mode on removable media without in-RAM", func() {
+			Expect(utils.UkiSentinel(false, false)).To(Equal("uki_install_mode"))
+		})
+		It("UkiSentinel is boot mode on removable media with in-RAM", func() {
+			Expect(utils.UkiSentinel(false, true)).To(Equal("uki_boot_mode"))
+		})
+		It("SkipUKIUnlock only skips on removable media without in-RAM", func() {
+			Expect(utils.SkipUKIUnlock(false, false)).To(BeTrue())
+			Expect(utils.SkipUKIUnlock(false, true)).To(BeFalse())
+			Expect(utils.SkipUKIUnlock(true, false)).To(BeFalse())
+			Expect(utils.SkipUKIUnlock(true, true)).To(BeFalse())
+		})
 	})
 })

--- a/main.go
+++ b/main.go
@@ -55,6 +55,13 @@ func main() {
 		// shell from inside its own steps.
 		var normalBoot bool
 		switch {
+		case st.InRAM && utils.IsUKI():
+			// Trusted boot in-RAM: the UKI is already the whole system in
+			// RAM, so the regular UKI DAG applies — RegisterUKI keys off
+			// st.InRAM to add partition provisioning (encrypted with the TPM
+			// policy) and to skip the removable-media unlock/sentinel gates.
+			utils.KLog.Logger.Info().Msg("UKI booting in-RAM (kairos.ram) with OEM+persistent from disk!")
+			err = dag.RegisterUKI(st, g)
 		case st.InRAM:
 			// kairos.ram must win over DisableImmucore below: an in-RAM boot
 			// still has live:LABEL / netboot on the cmdline (that is how the

--- a/pkg/dag/dag_uki_boot.go
+++ b/pkg/dag/dag_uki_boot.go
@@ -43,11 +43,22 @@ func RegisterUKI(s *state.State, g *herd.Graph) error {
 	// TODO: Implement this properly and enable. Until then, no KMS for UKI.
 	//s.LogIfError(s.UKISetupNetwork(g), "uki network setup")
 
+	// In-RAM trusted boot: the UKI is PXE/ISO-served but OEM + persistent live
+	// on local disk. First boot may need to create them — and under trusted
+	// boot the freshly created partitions are immediately encrypted with the
+	// TPM PCR policy inside the ensure-partitions step, so unlock must wait
+	// for it.
+	ukiUnlockDeps := []string{cnst.OpSentinel, cnst.OpUkiUdev}
+	if s.InRAM {
+		s.LogIfError(s.EnsurePartitionsDagStep(g, cnst.OpSentinel, cnst.OpUkiUdev), "ensure partitions")
+		ukiUnlockDeps = append(ukiUnlockDeps, cnst.OpEnsurePartitions)
+	}
+
 	// Unlock partitions if needed with TPM
 	// TODO: Make it depend on network setup for remote KMS access, as soon as we
 	// fix the OpUkiNetwork step.
 	//s.LogIfError(s.UKIUnlock(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev, cnst.OpUkiNetwork)), "uki unlock")
-	s.LogIfError(s.UKIUnlock(g, herd.WithDeps(cnst.OpSentinel, cnst.OpUkiUdev)), "uki unlock")
+	s.LogIfError(s.UKIUnlock(g, herd.WithDeps(ukiUnlockDeps...)), "uki unlock")
 
 	s.LogIfError(s.MountOemDagStep(g, herd.WithDeps(cnst.OpUkiKcrypt), herd.WeakDeps), "oem mount")
 

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -88,6 +88,32 @@ var _ = Describe("mounting immutable setup", func() {
 			checkInRAMDag(g.Analyze(), s.WriteDAG(g))
 		})
 
+		It("generates UKI dag without ensure-partitions", func() {
+			s := &state.State{Rootdir: "/"}
+			err := dag.RegisterUKI(s, g)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(layerOf(g.Analyze(), cnst.OpEnsurePartitions)).To(Equal(-1), s.WriteDAG(g))
+		})
+
+		It("generates UKI in-RAM dag with ensure-partitions gating unlock and OEM", func() {
+			s := &state.State{Rootdir: "/", InRAM: true}
+			err := dag.RegisterUKI(s, g)
+			Expect(err).ToNot(HaveOccurred())
+			layers := g.Analyze()
+			actualDag := s.WriteDAG(g)
+
+			ensure := layerOf(layers, cnst.OpEnsurePartitions)
+			udev := layerOf(layers, cnst.OpUkiUdev)
+			unlock := layerOf(layers, cnst.OpUkiKcrypt)
+			oem := layerOf(layers, cnst.OpMountOEM)
+
+			// devices must be discovered before we scan/create partitions,
+			// partitions must exist before unlock, unlock before OEM mount.
+			Expect(ensure).To(BeNumerically(">", udev), actualDag)
+			Expect(unlock).To(BeNumerically(">", ensure), actualDag)
+			Expect(oem).To(BeNumerically(">", unlock), actualDag)
+		})
+
 		It("Mountop timeouts", func() {
 			_, err := op.MountOPWithFstab("/dev/doesntexist", "/tmp/jojobizarreadventure", "", []string{}, 500*time.Millisecond)
 			Expect(err).To(HaveOccurred())
@@ -95,6 +121,19 @@ var _ = Describe("mounting immutable setup", func() {
 		})
 	})
 })
+
+// layerOf returns the index of the DAG layer containing the named op, or -1
+// when the op is not registered at all.
+func layerOf(dag [][]herd.GraphEntry, name string) int {
+	for i, layer := range dag {
+		for _, e := range layer {
+			if e.Name == name {
+				return i
+			}
+		}
+	}
+	return -1
+}
 
 func checkLiveCDDag(dag [][]herd.GraphEntry, actualDag string) {
 	Expect(len(dag)).To(Equal(5), actualDag)

--- a/pkg/state/steps_ensure_partitions.go
+++ b/pkg/state/steps_ensure_partitions.go
@@ -9,6 +9,7 @@ import (
 	cnst "github.com/kairos-io/immucore/internal/constants"
 	internalUtils "github.com/kairos-io/immucore/internal/utils"
 	sdkConstants "github.com/kairos-io/kairos-sdk/constants"
+	"github.com/kairos-io/kairos-sdk/kcrypt"
 	"github.com/spectrocloud-labs/herd"
 )
 
@@ -149,9 +150,44 @@ func (s *State) EnsurePartitionsDagStep(g *herd.Graph, deps ...string) error {
 				// the step normally.
 				return failErr
 			}
+			// Trusted boot: partitions created under UKI must be encrypted
+			// with the TPM PCR policy right away, exactly like kairos-agent
+			// does on a regular trusted-boot install. The label survives on
+			// the LUKS header, so every later boot sees them present and this
+			// whole step no-ops.
+			if internalUtils.IsUKI() {
+				for _, label := range internalUtils.PartitionsToEncrypt(oemFound, persistentFound) {
+					internalUtils.KLog.Logger.Info().Str("partition", label).Msg("encrypting freshly created partition with TPM policy")
+					if err := encryptPartitionFn(label); err != nil {
+						failErr := fmt.Errorf("encrypting partition %s: %w", label, err)
+						internalUtils.HaltWithBanner(
+							internalUtils.RenderEncryptionFailedMessage(label, failErr),
+							"partition encryption failed",
+							failErr,
+						)
+						// Reached only on non-systemd hosts (Alpine/openrc),
+						// where HaltWithBanner paints the screen and returns so
+						// we can fail the step normally.
+						return failErr
+					}
+				}
+			}
+
 			internalUtils.KLog.Logger.Info().Msg("kairos partitions ready")
 			return nil
 		}))
+}
+
+// encryptPartitionFn encrypts one freshly created partition by label using
+// the encryptor kcrypt derives from the system configuration — under UKI
+// that is the TPM PCR policy (remote KMS needs network, which UKI initramfs
+// does not set up yet). Package variable so tests can stub the TPM away.
+var encryptPartitionFn = func(label string) error {
+	encryptor, err := kcrypt.GetEncryptor(internalUtils.KLog)
+	if err != nil {
+		return err
+	}
+	return encryptor.Encrypt([]string{label})
 }
 
 // selectTargetDisk resolves the effective target disk. explicit wins when

--- a/pkg/state/steps_ensure_partitions.go
+++ b/pkg/state/steps_ensure_partitions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	cnst "github.com/kairos-io/immucore/internal/constants"
@@ -34,6 +35,12 @@ func (s *State) EnsurePartitionsDagStep(g *herd.Graph, deps ...string) error {
 	return g.Add(cnst.OpEnsurePartitions,
 		herd.WithDeps(deps...),
 		TimedCallback(cnst.OpEnsurePartitions, func(ctx context.Context) error {
+			// Under UKI immucore is PID1 and nothing has set PATH yet —
+			// yip's layout plugin and the encryption tooling resolve
+			// parted/mkfs/cryptsetup via LookPath. Same setup UKIUnlock does.
+			if internalUtils.IsUKI() {
+				_ = os.Setenv("PATH", "/usr/bin:/usr/sbin:/bin:/sbin")
+			}
 			oemFound, persistentFound, err := internalUtils.KairosPartitionsPresent()
 			if err != nil {
 				return fmt.Errorf("scanning disks for kairos partitions: %w", err)
@@ -156,6 +163,14 @@ func (s *State) EnsurePartitionsDagStep(g *herd.Graph, deps ...string) error {
 			// the LUKS header, so every later boot sees them present and this
 			// whole step no-ops.
 			if internalUtils.IsUKI() {
+				// systemd-cryptenroll reads the TPM SRK public key from
+				// /run/systemd/, where systemd-tpm2-setup normally puts it
+				// during boot — but immucore IS init here, so nobody has run
+				// it yet. Failure is only logged: cryptenroll surfaces the
+				// real error if the key is genuinely unobtainable.
+				if out, err := internalUtils.CommandWithPath("/usr/lib/systemd/systemd-tpm2-setup --early=yes"); err != nil {
+					internalUtils.KLog.Logger.Warn().Err(err).Str("out", out).Msg("systemd-tpm2-setup failed; TPM enrollment may not work")
+				}
 				for _, label := range internalUtils.PartitionsToEncrypt(oemFound, persistentFound) {
 					internalUtils.KLog.Logger.Info().Str("partition", label).Msg("encrypting freshly created partition with TPM policy")
 					if err := encryptPartitionFn(label); err != nil {

--- a/pkg/state/steps_shared.go
+++ b/pkg/state/steps_shared.go
@@ -77,23 +77,17 @@ func (s *State) WriteSentinelDagStep(g *herd.Graph, deps ...string) error {
 				}
 			}
 
-			// Lets add a uki sentinel as well!
+			// Lets add a uki sentinel as well! In-RAM UKI boots come from
+			// removable/network media but must behave like an installed
+			// Active system, so they get uki_boot_mode, never
+			// uki_install_mode (which would fire the installer stages).
 			cmdline, _ := os.ReadFile(internalUtils.GetHostProcCmdline())
 			if strings.Contains(string(cmdline), "rd.immucore.uki") {
 				state.DetectUKIboot(string(cmdline))
-				// sentinel for uki mode
-				if state.EfiBootFromInstall(internalUtils.KLog.Logger) {
-					internalUtils.KLog.Logger.Info().Str("to", "uki_boot_mode").Msg("Setting sentinel file")
-					err = os.WriteFile("/run/cos/uki_boot_mode", []byte("1"), os.ModePerm)
-					if err != nil {
-						return err
-					}
-				} else {
-					internalUtils.KLog.Logger.Info().Str("to", "uki_install_mode").Msg("Setting sentinel file")
-					err := os.WriteFile("/run/cos/uki_install_mode", []byte("1"), os.ModePerm)
-					if err != nil {
-						return err
-					}
+				ukiSentinel := internalUtils.UkiSentinel(state.EfiBootFromInstall(internalUtils.KLog.Logger), s.InRAM)
+				internalUtils.KLog.Logger.Info().Str("to", ukiSentinel).Msg("Setting sentinel file")
+				if err := os.WriteFile(filepath.Join("/run/cos/", ukiSentinel), []byte("1"), os.ModePerm); err != nil {
+					return err
 				}
 			}
 

--- a/pkg/state/steps_shared.go
+++ b/pkg/state/steps_shared.go
@@ -77,7 +77,7 @@ func (s *State) WriteSentinelDagStep(g *herd.Graph, deps ...string) error {
 				}
 			}
 
-			// Lets add a uki sentinel as well! In-RAM UKI boots come from
+			// Let's add a uki sentinel as well! In-RAM UKI boots come from
 			// removable/network media but must behave like an installed
 			// Active system, so they get uki_boot_mode, never
 			// uki_install_mode (which would fire the installer stages).

--- a/pkg/state/steps_shared.go
+++ b/pkg/state/steps_shared.go
@@ -81,9 +81,11 @@ func (s *State) WriteSentinelDagStep(g *herd.Graph, deps ...string) error {
 			// removable/network media but must behave like an installed
 			// Active system, so they get uki_boot_mode, never
 			// uki_install_mode (which would fire the installer stages).
-			cmdline, _ := os.ReadFile(internalUtils.GetHostProcCmdline())
-			if strings.Contains(string(cmdline), "rd.immucore.uki") {
-				state.DetectUKIboot(string(cmdline))
+cmdline, err := os.ReadFile(internalUtils.GetHostProcCmdline())
+if err != nil {
+	return fmt.Errorf("reading kernel cmdline: %w", err)
+}
+if strings.Contains(string(cmdline), "rd.immucore.uki") {
 				ukiSentinel := internalUtils.UkiSentinel(state.EfiBootFromInstall(internalUtils.KLog.Logger), s.InRAM)
 				internalUtils.KLog.Logger.Info().Str("to", ukiSentinel).Msg("Setting sentinel file")
 				if err := os.WriteFile(filepath.Join("/run/cos/", ukiSentinel), []byte("1"), os.ModePerm); err != nil {

--- a/pkg/state/steps_uki.go
+++ b/pkg/state/steps_uki.go
@@ -519,8 +519,10 @@ func (s *State) UKISetupNetwork(g *herd.Graph) error {
 // (PATH, removable media check, reboot on error).
 func (s *State) UKIUnlock(g *herd.Graph, opts ...herd.OpOption) error {
 	return g.Add(cnst.OpUkiKcrypt, append(opts, TimedCallback(cnst.OpUkiKcrypt, func(_ context.Context) error {
-		// Check if booting from removable media (live CD)
-		if !state.EfiBootFromInstall(internalUtils.KLog.Logger) {
+		// Check if booting from removable media (live CD). The in-RAM
+		// workflow boots from removable/network media on purpose and still
+		// owns encrypted partitions on disk, so it never skips.
+		if internalUtils.SkipUKIUnlock(state.EfiBootFromInstall(internalUtils.KLog.Logger), s.InRAM) {
 			internalUtils.KLog.Logger.Debug().Msg("Not unlocking disks as we think we are booting from removable media")
 			return nil
 		}


### PR DESCRIPTION
Combining `kairos.ram*` with `rd.immucore.uki` was broken. Dispatch sent that combo down the dracut-based in-RAM DAG, which waits forever on a dracut-staged `/sysroot` that never appears under UKI. It now routes to `RegisterUKI`, and the in-RAM bits are wired into the UKI graph instead.

When `State.InRAM`, `RegisterUKI` registers `EnsurePartitionsDagStep` between udev and the TPM unlock step, and unlock depends on it. Partitions created there are encrypted immediately through kairos-sdk `kcrypt.GetEncryptor().Encrypt` — the same systemd-cryptenroll PCR policy enrollment kairos-agent does on a trusted boot install. No plaintext fallback and no remote KMS: the UKI initramfs has no network at unlock time, so a failure paints `RenderEncryptionFailedMessage` and halts rather than booting something silently unprotected. `PartitionsToEncrypt` keeps that scoped to partitions we just created, pre-existing ones are left alone.

Two behaviour fixes go with it:

- `UKIUnlock` no longer skips unlocking on removable media boots when in-RAM — a PXE or ISO served UKI still owns encrypted partitions on disk. The decision is now the pure `SkipUKIUnlock`
- in-RAM UKI boots write the `uki_boot_mode` sentinel instead of `uki_install_mode` (`UkiSentinel`), so the installer cloud-init stages stay quiet on a machine that already has its OEM and persistent partitions

README gets a section on what the `kairos.ram.*` stanzas mean under trusted boot.

Tested with ginkgo specs for the new pure helpers and DAG-shape tests asserting `ensure-partitions` gates unlock and OEM in the UKI in-RAM graph and is absent from plain UKI, plus `--dry-run` graph inspection for the UKI+ram, plain UKI and plain in-RAM cmdlines. Since then also verified end to end in QEMU (secureboot OVMF + swtpm, harness lives in kairos-io/skills now): first boot creates and TPM-encrypts OEM and persistent with a systemd-tpm2 LUKS token, second boot on the same disk is a no-op for ensure-partitions and unlocks via TPM, and data written to the encrypted persistent partition survives the reboot.

Signed-off-by: Itxaka <itxaka@kairos.io>

