### PR TITLE
chore(deps): consume legacy unlock SDK fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jaypipes/ghw v0.25.0
 	github.com/joho/godotenv v1.5.1
-	github.com/kairos-io/kairos-sdk v0.25.1
+	github.com/kairos-io/kairos-sdk v0.25.2-0.20260805143930-4d8b3f8e770b
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/mudler/yip v1.25.1
 	github.com/onsi/ginkgo/v2 v2.32.0

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,8 @@ github.com/jzelinskie/whirlpool v0.0.0-20201016144138-0675e54bb004 h1:G+9t9cEtnC
 github.com/jzelinskie/whirlpool v0.0.0-20201016144138-0675e54bb004/go.mod h1:KmHnJWQrgEvbuy0vcvj00gtMqbvNn1L+3YUZLK/B92c=
 github.com/kairos-io/kairos-sdk v0.25.1 h1:52Ptex/9AE26mZQruOKuyiLQieV5hzPmV1xfmnYtzR8=
 github.com/kairos-io/kairos-sdk v0.25.1/go.mod h1:ebgJNvYL9JbE4ndZYk7bFCTCdJBFMTAiQvmxm2Ia5Pw=
+github.com/kairos-io/kairos-sdk v0.25.2-0.20260805143930-4d8b3f8e770b h1:O3Abh4NU+MsKp8scfSAoAtirY/PQgmqlB4kYS7LZvoU=
+github.com/kairos-io/kairos-sdk v0.25.2-0.20260805143930-4d8b3f8e770b/go.mod h1:ebgJNvYL9JbE4ndZYk7bFCTCdJBFMTAiQvmxm2Ia5Pw=
 github.com/kairos-io/tpm-helpers v0.0.0-20260702080541-9b3e057e2f32 h1:uunggNSibnMrKkvBblxmpsa1BNGHXFqsJf0zyUm0Eas=
 github.com/kairos-io/tpm-helpers v0.0.0-20260702080541-9b3e057e2f32/go.mod h1:VCNa+JJQgXutnWNJvZyNSemeMSy2w+b9SKTkItiIkro=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=


### PR DESCRIPTION
## Summary\n\nPin kairos-sdk to the merged legacy unlabeled-partition unlock fix from kairos-sdk#822. The selected SDK commit also contains the live-media GRUB helper from kairos-sdk#823.\n\n## Testing\n\nThe updated module and checksum were resolved directly from GitHub. Targeted Go tests could not start because this environment receives HTTP 403 while fetching unrelated modules from their vanity domains. CI will perform the full verification.\n\nSigned-off-by: Ettore Di Giacinto <mudler@localai.io>