### PR TITLE
fix: a missing ephemeral overlay path no longer skips every persistent bind

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -90,6 +90,11 @@ func GenericKernelDrivers() []string {
 
 var ErrAlreadyMounted = errors.New("already mounted")
 
+// ErrMountTargetMissing is returned when a mount target directory does not exist
+// and cannot be created, typically because it is missing from the OS image and
+// the rootfs is still mounted read-only at that point in the boot.
+var ErrMountTargetMissing = errors.New("mount target does not exist and could not be created")
+
 const (
 	OpCustomMounts         = "custom-mount"
 	OpDiscoverState        = "discover-state"

--- a/pkg/op/fs.go
+++ b/pkg/op/fs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/mount"
+	"github.com/kairos-io/immucore/internal/constants"
 	internalUtils "github.com/kairos-io/immucore/internal/utils"
 	"github.com/kairos-io/immucore/pkg/schema"
 )
@@ -108,8 +109,6 @@ func MountWithBaseOverlay(mountpoint, root, base string) MountOperation {
 	rootMount := filepath.Join(root, mountpoint)
 	bindMountPath := strings.ReplaceAll(mountpoint, "/", "-")
 
-	// TODO: Should we error out if we cant create the target to mount to?
-	_ = internalUtils.CreateIfNotExists(rootMount)
 	upperdir := filepath.Join(base, bindMountPath, ".overlay", "upper")
 	workdir := filepath.Join(base, bindMountPath, ".overlay", "work")
 
@@ -133,6 +132,14 @@ func MountWithBaseOverlay(mountpoint, root, base string) MountOperation {
 		FstabEntry:  *tmpFstab,
 		Target:      rootMount,
 		PrepareCallback: func() error {
+			// The lowerdir has to exist before we can stack an overlay on it. It
+			// usually ships in the OS image, but if it does not we cannot create it
+			// either: the rootfs is still mounted read-only at this point. Report
+			// that clearly instead of letting the mount syscall fail later with a
+			// bare "lstat <path>: no such file or directory".
+			if err := internalUtils.CreateIfNotExists(rootMount); err != nil {
+				return fmt.Errorf("%w: %s: %w", constants.ErrMountTargetMissing, rootMount, err)
+			}
 			// Make sure workdir and/or upper exists
 			_ = os.MkdirAll(upperdir, os.ModePerm)
 			_ = os.MkdirAll(workdir, os.ModePerm)

--- a/pkg/op/fs_test.go
+++ b/pkg/op/fs_test.go
@@ -1,0 +1,45 @@
+package op_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/kairos-io/immucore/internal/constants"
+	"github.com/kairos-io/immucore/pkg/op"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MountWithBaseOverlay", func() {
+	var root, base string
+
+	BeforeEach(func() {
+		root = GinkgoT().TempDir()
+		base = GinkgoT().TempDir()
+	})
+
+	It("creates the lowerdir when it is missing from the image", func() {
+		operation := op.MountWithBaseOverlay("mnt", root, base)
+
+		Expect(operation.PrepareCallback()).ToNot(HaveOccurred())
+		Expect(filepath.Join(root, "mnt")).To(BeADirectory())
+	})
+
+	It("reports ErrMountTargetMissing when the lowerdir cannot be created", func() {
+		if os.Geteuid() == 0 {
+			Skip("root bypasses directory write permissions")
+		}
+		// Stands in for the real case: the path is absent from the OS image and the
+		// rootfs is still mounted read-only, so MkdirAll cannot create it either.
+		readOnly := filepath.Join(root, "readonly")
+		Expect(os.Mkdir(readOnly, 0500)).ToNot(HaveOccurred())
+
+		operation := op.MountWithBaseOverlay("mnt", readOnly, base)
+
+		err := operation.PrepareCallback()
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, constants.ErrMountTargetMissing)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring(filepath.Join(readOnly, "mnt")))
+	})
+})

--- a/pkg/op/suite_test.go
+++ b/pkg/op/suite_test.go
@@ -1,0 +1,13 @@
+package op_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Op test Suite")
+}

--- a/pkg/state/steps_shared.go
+++ b/pkg/state/steps_shared.go
@@ -302,6 +302,17 @@ func (s *State) MountCustomOverlayDagStep(g *herd.Graph, opts ...herd.OpOption) 
 						internalUtils.KLog.Logger.Debug().Str("what", p).Msg("Overlay mount start")
 						operation := op.MountWithBaseOverlay(p, s.Rootdir, "/run/overlay")
 						err := operation.Run()
+						// A path that is missing from the OS image cannot be mounted, but it
+						// must not take the whole step down with it: OpMountBind depends on
+						// this one, so failing here silently skips every persistent state
+						// bind (/etc/systemd, /etc/sysconfig, /home, /var/lib/rancher, ...)
+						// and the node boots with a pristine image /etc. Losing one ephemeral
+						// RW path is far less damaging, so warn loudly and carry on.
+						if errors.Is(err, cnst.ErrMountTargetMissing) {
+							internalUtils.KLog.Logger.Warn().Err(err).Str("what", p).
+								Msg("Skipping ephemeral overlay: path is not in the OS image. Writes to it will fail against the read-only rootfs. Create the directory at image build time or drop it from ephemeral_mounts/RW_PATHS.")
+							continue
+						}
 						// Append to errors only if it's not an already mounted error
 						if err != nil && !errors.Is(err, cnst.ErrAlreadyMounted) {
 							internalUtils.KLog.Logger.Err(err).Msg("overlay mount")


### PR DESCRIPTION
## What happened

After a `kairos-operator` upgrade, a k3s agent node came up with what looked like
its entire configuration gone: no `k3s-agent` systemd drop-in, no
`/etc/sysconfig/k3s-agent`, an empty `/home`, and sysext setup failing. Nothing
was actually lost — `/usr/local/.state/` was fully intact — but **none of the
persistent state binds were mounted**, so the node was running on a pristine
image `/etc`.

`findmnt` showed only `/usr/local` mounted and not a single `.bind`, while
`/usr/local/.state/` held all 40+ bind directories, including
`etc-systemd.bind/system/k3s-agent.service.d/override.conf` with the correct
contents and its original mtime.

## Root cause

The node's config lists `/mnt` in `ephemeral_mounts`, which lands in `RW_PATHS`:

```
RW_PATHS="/var /etc /srv /mnt"
```

Rocky Linux 10 does not ship `/mnt`. `MountWithBaseOverlay` needs that directory
to exist to use as the overlay lowerdir, and it cannot create it either: at that
point in the boot `/sysroot` is still mounted read-only.

```
INF mount done options=["ro","suid","dev","exec","async"] type=ext4 what=/dev/disk/by-label/COS_ACTIVE where=/sysroot
```

`CreateIfNotExists`' error was discarded (`_ =`, with a `TODO: Should we error
out if we cant create the target to mount to?`), so the first sign of trouble was
the mount syscall failing later with a bare `lstat`:

```
WRN checking mount status error="lstat /sysroot/mnt: no such file or directory" options=["lowerdir=/sysroot/mnt",...]
ERR overlay mount error="lstat /sysroot/mnt: no such file or directory"
```

That single failure then took down far more than the path it applied to.
`OpMountBind` declares `herd.WithDeps(cnst.OpOverlayMount, ...)`, so a non-nil
error from the overlay step marks the dependency as failed and skips the bind
step wholesale:

```
(error: 'mount-bind' deps overlay-mount failed)
(error: 'enable-sysext-confext' deps overlay-mount failed)
```

So one directory missing from the image silently costs every persistent state
bind — `/etc/systemd`, `/etc/sysconfig`, `/etc/rancher`, `/home`,
`/var/lib/rancher`, all of them. On a Kubernetes node that presents as "my
configuration disappeared after an upgrade" rather than as a mount failure, which
makes it genuinely hard to trace: the config is still on disk, just not bound
over.

## The fix

Two small changes:

1. `MountWithBaseOverlay` now creates the lowerdir in its `PrepareCallback` and
   returns `constants.ErrMountTargetMissing` (wrapping the underlying error and
   naming the path) instead of discarding the failure. The `TODO` is answered.
2. `MountCustomOverlayDagStep` treats that specific error as a skip rather than a
   step failure, following the existing `ErrAlreadyMounted` pattern, and warns
   with the path and the remedy.

The trade-off is deliberate: an ephemeral RW path that is missing from the image
was never going to work on that boot either way, and writes to it will fail
against the read-only rootfs. Silently losing all persistent state is a far worse
outcome than losing one ephemeral overlay, so the step now degrades instead of
cascading. Every other overlay error aggregates into the multierror exactly as
before.

Happy to take this a different direction if you'd prefer — making `OpMountBind`'s
dependency on `OpOverlayMount` a weak dep would also break the cascade while
keeping the ordering, but it changes failure semantics for every overlay error
rather than just this one, so I went with the narrower change.

## Testing

- Added `pkg/op/fs_test.go` (with a `suite_test.go`, `pkg/op` had no suite):
  covers both the create-succeeds and cannot-create paths. The error spec skips
  under uid 0 since root bypasses directory write permissions; it was verified
  passing as a non-root user, not just skipped.
- `go build ./...`, `go vet ./...` and `go test ./...` all pass.

## Environment

- immucore `v0.18.0` (commit `03ce6004d48d228697e7c76e152f56f163324b08`)
- kairos-init `v0.16.1`, kairos-agent `v2.30.2`
- Rocky Linux 10.2, k3s `v1.36.3+k3s1`, non-UKI, active boot