### PR TITLE
fix: resolve the sysroot labels for an AutoReset boot

### DIFF
--- a/internal/utils/bootstate_internal_test.go
+++ b/internal/utils/bootstate_internal_test.go
@@ -1,49 +1,33 @@
 package utils
 
 import (
-	"testing"
-
 	"github.com/kairos-io/kairos-sdk/state"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// The statereset GRUB entry boots the recovery image with kairos.reset on the
-// cmdline. kairos-sdk v0.25.0 started reporting that boot as AutoReset instead
-// of Recovery for non-UKI systems, which left both label lookups falling
-// through to their empty/error default. sysroot then had no device, the boot
-// died in the initramfs, and the machine rebooted into the old system with the
-// persistent partition untouched.
-func TestBootStateToSysrootLabel(t *testing.T) {
-	for _, tt := range []struct {
-		boot state.Boot
-		want string
-	}{
-		{state.Active, "COS_ACTIVE"},
-		{state.Passive, "COS_PASSIVE"},
-		{state.Recovery, "COS_SYSTEM"},
-		{state.AutoReset, "COS_SYSTEM"},
-		{state.LiveCD, ""},
-		{state.Unknown, ""},
-	} {
-		if got := bootStateToSysrootLabel(tt.boot); got != tt.want {
-			t.Errorf("bootStateToSysrootLabel(%q) = %q, want %q", tt.boot, got, tt.want)
-		}
-	}
-}
+var _ = Describe("boot state to label", func() {
+	DescribeTable("resolves the sysroot label",
+		func(boot state.Boot, expected string) {
+			Expect(bootStateToSysrootLabel(boot)).To(Equal(expected))
+		},
+		Entry("active", state.Active, "COS_ACTIVE"),
+		Entry("passive", state.Passive, "COS_PASSIVE"),
+		Entry("recovery", state.Recovery, "COS_SYSTEM"),
+		Entry("autoreset boots the recovery image", state.AutoReset, "COS_SYSTEM"),
+		Entry("livecd has no target", state.LiveCD, ""),
+		Entry("unknown has no target", state.Unknown, ""),
+	)
 
-func TestBootStateToImagesLabel(t *testing.T) {
-	for _, tt := range []struct {
-		boot state.Boot
-		want string
-	}{
-		{state.Active, "COS_STATE"},
-		{state.Passive, "COS_STATE"},
-		{state.Recovery, "COS_RECOVERY"},
-		{state.AutoReset, "COS_RECOVERY"},
-		{state.LiveCD, ""},
-		{state.Unknown, ""},
-	} {
-		if got := bootStateToImagesLabel(tt.boot); got != tt.want {
-			t.Errorf("bootStateToImagesLabel(%q) = %q, want %q", tt.boot, got, tt.want)
-		}
-	}
-}
+	DescribeTable("resolves the images label",
+		func(boot state.Boot, expected string) {
+			Expect(bootStateToImagesLabel(boot)).To(Equal(expected))
+		},
+		Entry("active", state.Active, "COS_STATE"),
+		Entry("passive", state.Passive, "COS_STATE"),
+		Entry("recovery", state.Recovery, "COS_RECOVERY"),
+		Entry("autoreset boots the recovery image", state.AutoReset, "COS_RECOVERY"),
+		Entry("livecd has no target", state.LiveCD, ""),
+		Entry("unknown has no target", state.Unknown, ""),
+	)
+})

--- a/internal/utils/bootstate_internal_test.go
+++ b/internal/utils/bootstate_internal_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/kairos-io/kairos-sdk/state"
+)
+
+// The statereset GRUB entry boots the recovery image with kairos.reset on the
+// cmdline. kairos-sdk v0.25.0 started reporting that boot as AutoReset instead
+// of Recovery for non-UKI systems, which left both label lookups falling
+// through to their empty/error default. sysroot then had no device, the boot
+// died in the initramfs, and the machine rebooted into the old system with the
+// persistent partition untouched.
+func TestBootStateToSysrootLabel(t *testing.T) {
+	for _, tt := range []struct {
+		boot state.Boot
+		want string
+	}{
+		{state.Active, "COS_ACTIVE"},
+		{state.Passive, "COS_PASSIVE"},
+		{state.Recovery, "COS_SYSTEM"},
+		{state.AutoReset, "COS_SYSTEM"},
+		{state.LiveCD, ""},
+		{state.Unknown, ""},
+	} {
+		if got := bootStateToSysrootLabel(tt.boot); got != tt.want {
+			t.Errorf("bootStateToSysrootLabel(%q) = %q, want %q", tt.boot, got, tt.want)
+		}
+	}
+}
+
+func TestBootStateToImagesLabel(t *testing.T) {
+	for _, tt := range []struct {
+		boot state.Boot
+		want string
+	}{
+		{state.Active, "COS_STATE"},
+		{state.Passive, "COS_STATE"},
+		{state.Recovery, "COS_RECOVERY"},
+		{state.AutoReset, "COS_RECOVERY"},
+		{state.LiveCD, ""},
+		{state.Unknown, ""},
+	} {
+		if got := bootStateToImagesLabel(tt.boot); got != tt.want {
+			t.Errorf("bootStateToImagesLabel(%q) = %q, want %q", tt.boot, got, tt.want)
+		}
+	}
+}

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -24,16 +24,8 @@ import (
 // bootStateToSysrootLabel maps a boot state to the filesystem label of the
 // image that becomes sysroot. It returns an empty string for a state we cannot
 // mount from (LiveCD, Unknown), which callers treat as "no target".
-//
-// AutoReset is the statereset boot. It runs the recovery image and then resets,
-// so it resolves exactly like Recovery. kairos-sdk only reported AutoReset for
-// UKI boots until v0.25.0, when getNonUKIBootState started matching
-// kairos.reset ahead of COS_SYSTEM. A non-UKI statereset boot therefore reaches
-// this function as AutoReset, and without this arm sysroot got an empty label
-// and the boot died in the initramfs.
-//
-// It is split from BootStateToLabelDevice because the state lookup reads the
-// real /proc/cmdline, which a unit test cannot stub.
+// AutoReset runs the recovery image and then resets, so it resolves like
+// Recovery.
 func bootStateToSysrootLabel(b state.Boot) string {
 	switch b {
 	case state.Active:
@@ -49,7 +41,7 @@ func bootStateToSysrootLabel(b state.Boot) string {
 
 // bootStateToImagesLabel maps a boot state to the label of the partition that
 // holds the boot images. AutoReset boots the recovery image, so its images live
-// on the recovery partition. See bootStateToSysrootLabel.
+// on the recovery partition.
 func bootStateToImagesLabel(b state.Boot) string {
 	switch b {
 	case state.Active, state.Passive:

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -21,22 +21,57 @@ import (
 	"golang.org/x/term"
 )
 
+// bootStateToSysrootLabel maps a boot state to the filesystem label of the
+// image that becomes sysroot. It returns an empty string for a state we cannot
+// mount from (LiveCD, Unknown), which callers treat as "no target".
+//
+// AutoReset is the statereset boot. It runs the recovery image and then resets,
+// so it resolves exactly like Recovery. kairos-sdk only reported AutoReset for
+// UKI boots until v0.25.0, when getNonUKIBootState started matching
+// kairos.reset ahead of COS_SYSTEM. A non-UKI statereset boot therefore reaches
+// this function as AutoReset, and without this arm sysroot got an empty label
+// and the boot died in the initramfs.
+//
+// It is split from BootStateToLabelDevice because the state lookup reads the
+// real /proc/cmdline, which a unit test cannot stub.
+func bootStateToSysrootLabel(b state.Boot) string {
+	switch b {
+	case state.Active:
+		return "COS_ACTIVE"
+	case state.Passive:
+		return "COS_PASSIVE"
+	case state.Recovery, state.AutoReset:
+		return "COS_SYSTEM"
+	default:
+		return ""
+	}
+}
+
+// bootStateToImagesLabel maps a boot state to the label of the partition that
+// holds the boot images. AutoReset boots the recovery image, so its images live
+// on the recovery partition. See bootStateToSysrootLabel.
+func bootStateToImagesLabel(b state.Boot) string {
+	switch b {
+	case state.Active, state.Passive:
+		return "COS_STATE"
+	case state.Recovery, state.AutoReset:
+		return "COS_RECOVERY"
+	default:
+		return ""
+	}
+}
+
 // BootStateToLabelDevice lets us know the device we need to mount sysroot on based on labels.
 func BootStateToLabelDevice() string {
 	runtime, err := state.NewRuntimeWithLogger(KLog.Logger)
 	if err != nil {
 		return ""
 	}
-	switch runtime.BootState {
-	case state.Active:
-		return filepath.Join("/dev/disk/by-label", "COS_ACTIVE")
-	case state.Passive:
-		return filepath.Join("/dev/disk/by-label", "COS_PASSIVE")
-	case state.Recovery:
-		return filepath.Join("/dev/disk/by-label", "COS_SYSTEM")
-	default:
+	label := bootStateToSysrootLabel(runtime.BootState)
+	if label == "" {
 		return ""
 	}
+	return filepath.Join("/dev/disk/by-label", label)
 }
 
 // GetRootDir returns the proper dir to mount all the stuff
@@ -442,12 +477,8 @@ func GetState() string {
 			if err != nil {
 				return err
 			}
-			switch r.BootState {
-			case state.Active, state.Passive:
-				label = "COS_STATE"
-			case state.Recovery:
-				label = "COS_RECOVERY"
-			default:
+			label = bootStateToImagesLabel(r.BootState)
+			if label == "" {
 				return errors.New("could not get label")
 			}
 			return nil


### PR DESCRIPTION
Fixes the reset failure reported in kairos-io/kairos#4314.

## What this fixes

**An automatic state reset does nothing on BIOS/GRUB (non-UKI) installs, and says nothing about it.**

```bash
touch /usr/local/test
grub2-editenv /oem/grubenv set next_entry=statereset
reboot
```

Expected: the system resets, and `/usr/local/test` is gone.
Actual: the system reboots twice, comes back on active, and `/usr/local/test` is still there. The persistent partition is untouched.

In CI this is the `reset tests` and `reset tests (FIPS)` failure in `hadron`, at `tests/acceptance_test.go:283`:

```
Expected <string>: ok
To satisfy at least one of these matchers: [ContainSubstring wrong]
```

That assertion checks that `/usr/local/test` is gone after the reset.

**It fixes only that failure.** To be explicit about what it does not touch:

- `custom-partitioning tests` — fails on unrelated pull requests too, and is a separate problem.
- A `reset tests` run that times out in `[BeforeEach]` because the VM never booted — infrastructure flakiness, not this.
- Trusted boot (UKI) — never affected, because the UKI path returns early from `GetTarget` and never reaches these two functions.

## Root cause

The `statereset` GRUB entry boots the recovery image with `kairos.reset` on the kernel command line.

`kairos-sdk` v0.25.0 added a case to `getNonUKIBootState`, placed above the `COS_SYSTEM` case that used to match:

```go
case strings.Contains(cmdline, "kairos.reset"):
    return AutoReset
```

So a non-UKI state reset now reports `AutoReset` where it reported `Recovery` before.

Neither `BootStateToLabelDevice` nor `GetState` had an `AutoReset` arm, so both fell through to their defaults. sysroot got an empty device, and `GetState` failed after its ten retries. The boot then died in the initramfs.

`immucore` already handles `AutoReset` where it writes the sentinel (`autoreset_mode`). That arm was only reachable from UKI boots until now, so these two functions never needed one.

## Why nobody saw an error

The reset entry inherits `rd.emergency=reboot` and `rd.shell=0`, so an initramfs failure reboots with no shell and no message. `next_entry` is one-shot, so the following boot goes to active. From the outside it is indistinguishable from a plain reboot.

On a serial console the boot stops after the initrd and restarts roughly 15 seconds later. That gap is `GetState`'s retry loop: 10 attempts, 1s fixed delay.

## Affected versions

| component | version | affected |
|---|---|---|
| `kairos-sdk` | ≤ v0.24.0 | no |
| `kairos-sdk` | ≥ v0.25.0 | introduces the change |
| `immucore` | v0.19.0 (pins SDK v0.24.0) | no |
| `immucore` | v0.20.0, v0.20.1 (pin SDK v0.25.2) | **yes** |

`main` still has both defaults and still pins SDK v0.25.2.

## The change

An `AutoReset` boot is a recovery boot that also runs the reset, so it resolves to the same labels as `Recovery`. The sentinel already distinguishes the two.

Both mappings move into small pure functions. The reason is testability: `BootStateToLabelDevice` and `GetState` call `state.NewRuntimeWithLogger`, which reads the real `/proc/cmdline`, and a unit test cannot stub that. The pure functions can be tested directly, and the new test fails without the fix:

```
--- FAIL: TestBootStateToSysrootLabel
    bootStateToSysrootLabel("autoreset_boot") = "", want "COS_SYSTEM"
--- FAIL: TestBootStateToImagesLabel
    bootStateToImagesLabel("autoreset_boot") = "", want "COS_RECOVERY"
```

If you would rather keep the diff minimal, the behavioural change is only two lines — adding `state.AutoReset` to each existing `case state.Recovery:`. Happy to reduce it to that and drop the test.

## Worth deciding separately

`kairos-sdk` changed what a shared classifier returns for an existing boot flow. This PR fixes `immucore`. It does not prevent another consumer of `state.Boot` from hitting the same edge, and I have not audited the rest of the org for that.
