### PR TITLE
fix: install the recovery extensions on an AutoReset boot

### DIFF
--- a/pkg/state/extensions_internal_test.go
+++ b/pkg/state/extensions_internal_test.go
@@ -1,0 +1,23 @@
+package state
+
+import (
+	"github.com/kairos-io/kairos-sdk/state"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("boot state to extension sub-directory", func() {
+	DescribeTable("resolves the sub-directory",
+		func(boot state.Boot, expected string, known bool) {
+			subDir, ok := bootStateToExtensionSubDir(boot)
+			Expect(ok).To(Equal(known))
+			Expect(subDir).To(Equal(expected))
+		},
+		Entry("active", state.Active, "active", true),
+		Entry("passive", state.Passive, "passive", true),
+		Entry("recovery", state.Recovery, "recovery", true),
+		Entry("autoreset runs the recovery image", state.AutoReset, "recovery", true),
+		Entry("livecd installs nothing", state.LiveCD, "", false),
+		Entry("unknown installs nothing", state.Unknown, "", false),
+	)
+})

--- a/pkg/state/steps_shared.go
+++ b/pkg/state/steps_shared.go
@@ -449,6 +449,23 @@ func (s *State) EnableSysAndConfExtensions(g *herd.Graph, opts ...herd.OpOption)
 	}))...)
 }
 
+// bootStateToExtensionSubDir returns the sub-directory of the extension source
+// that a boot state installs from. The second value is false for a boot state
+// that installs no extensions. AutoReset runs the recovery image, so it reads
+// the recovery directory.
+func bootStateToExtensionSubDir(b state.Boot) (string, bool) {
+	switch b {
+	case state.Active:
+		return "active", true
+	case state.Passive:
+		return "passive", true
+	case state.Recovery, state.AutoReset:
+		return "recovery", true
+	default:
+		return "", false
+	}
+}
+
 // validateAndEnableSysConfExtensions is the common logic for validating and enabling both sys and conf extensions,
 // as they work in a similar way, just different source and destination dirs and different validation for sys extensions.
 func validateAndEnableSysConfExtensions(s *State, extType string) error {
@@ -474,17 +491,12 @@ func validateAndEnableSysConfExtensions(s *State, extType string) error {
 		return errors.New("unknown extension type")
 	}
 
-	switch r.BootState {
-	case state.Active:
-		dir = filepath.Join(sourceDir, "active")
-	case state.Passive:
-		dir = filepath.Join(sourceDir, "passive")
-	case state.Recovery:
-		dir = filepath.Join(sourceDir, "recovery")
-	default:
+	subDir, known := bootStateToExtensionSubDir(r.BootState)
+	if !known {
 		internalUtils.KLog.Logger.Debug().Str("state", string(r.BootState)).Msg("Not copying sysextensions as we are not in a state that we know off")
 		return nil
 	}
+	dir = filepath.Join(sourceDir, subDir)
 	// move to use dir with the full path from here so its simpler
 	entries, err := os.ReadDir(s.path(dir))
 	// We don't care if the dir does not exist


### PR DESCRIPTION
Follow-up to #611. Same class of gap, third function.

## What breaks

`validateAndEnableSysConfExtensions` picks the extension source directory from the boot state:

```go
switch r.BootState {
case state.Active:   dir = filepath.Join(sourceDir, "active")
case state.Passive:  dir = filepath.Join(sourceDir, "passive")
case state.Recovery: dir = filepath.Join(sourceDir, "recovery")
default:
    // debug log only
    return nil
}
```

`kairos-sdk` `v0.25.0` reports a non-UKI `kairos.reset` boot as `AutoReset`. There is no arm for it, so the function returns early. **A state reset installs no system extensions and no configuration extensions.**

The only trace is a `Debug` log line, so a normal log level shows nothing at all.

## How this differs from #611

#611 fixed the two label functions. Without them the boot died in the initramfs, which was at least loud on a serial console. This one does not stop the boot. It drops the extensions and continues, which is harder to notice.

Both functions run on the same boot, so #611 had to land first for this path to be reachable at all.

## The change

An `AutoReset` boot runs the recovery image, so it reads the recovery directory, exactly like `Recovery`.

The mapping moves to a small pure function, `bootStateToExtensionSubDir`. The reason is testability: the caller builds a runtime from the real `/proc/cmdline`, which a unit test cannot stub. The specs follow the ginkgo style `@jimmykarily` asked for on #611.

If you would rather keep the diff minimal, the behavioural change is one line — adding `state.AutoReset` to the existing `case state.Recovery:`. Happy to reduce it to that and drop the specs.

## Verified

```
go build ./...            ok
go test ./pkg/state/...   19 of 21 specs pass
```

The specs catch the bug. With `state.AutoReset` removed from the arm:

```
[FAILED] boot state to extension sub-directory resolves the sub-directory
         [It] autoreset runs the recovery image
```

I did not build an image or run a state reset from this branch.

## Note, not part of this pull request

`gofmt` reports `pkg/state/steps_shared.go` as unformatted on `main` today, at lines 81-91 in `WriteSentinelDagStep`. That predates this branch and I left it alone, so this diff stays about one thing.

Refs: kairos-io/kairos#4314

---

AI assisted this pull request. Mauro is attending and directed it.
