### PR TITLE
ci: make a switch over state.Boot fail the lint when it misses a case

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   enable:
     - dupl
+    - exhaustive
     - ginkgolinter
     - gocheckcompilerdirectives
     - goconst
@@ -13,6 +14,12 @@ linters:
     - misspell
     - revive
     - zerologlint
+  settings:
+    exhaustive:
+      # Keep this false. Every switch that missed state.AutoReset in #611 and
+      # #613 already had a default arm. Set this to true and the linter stops
+      # reporting the exact shape of bug it is here to catch.
+      default-signifies-exhaustive: false
   exclusions:
     generated: lax
     presets:

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -34,6 +34,8 @@ func bootStateToSysrootLabel(b state.Boot) string {
 		return "COS_PASSIVE"
 	case state.Recovery, state.AutoReset:
 		return "COS_SYSTEM"
+	case state.LiveCD, state.Unknown:
+		return ""
 	default:
 		return ""
 	}
@@ -48,6 +50,8 @@ func bootStateToImagesLabel(b state.Boot) string {
 		return "COS_STATE"
 	case state.Recovery, state.AutoReset:
 		return "COS_RECOVERY"
+	case state.LiveCD, state.Unknown:
+		return ""
 	default:
 		return ""
 	}

--- a/pkg/state/steps_shared.go
+++ b/pkg/state/steps_shared.go
@@ -54,6 +54,8 @@ func (s *State) WriteSentinelDagStep(g *herd.Graph, deps ...string) error {
 				sentinel = "autoreset_mode"
 			case state.LiveCD:
 				sentinel = "live_mode"
+			case state.Unknown:
+				sentinel = string(state.Unknown)
 			default:
 				sentinel = string(state.Unknown)
 			}
@@ -461,6 +463,8 @@ func bootStateToExtensionSubDir(b state.Boot) (string, bool) {
 		return "passive", true
 	case state.Recovery, state.AutoReset:
 		return "recovery", true
+	case state.LiveCD, state.Unknown:
+		return "", false
 	default:
 		return "", false
 	}


### PR DESCRIPTION
Follow-up to #611 and #613. Neither of those pull requests stops the bug coming back. This one does.

## The pattern

Both were the same bug in three different functions: a `switch` over `state.Boot` with no `state.AutoReset` arm. Every one had a `default` arm, so every one compiled, ran, and quietly did the wrong thing.

`state.Boot` is a named type with six constants in one `const` block, so a linter can see the gap.

## Evidence

Run against the tree before either fix (`04cca6d`), `exhaustive` reports all three, and names the missing member:

```
internal/utils/common.go:30:2:    missing cases in switch of type state.Boot: state.LiveCD, state.AutoReset, state.Unknown
internal/utils/common.go:445:4:   missing cases in switch of type state.Boot: state.LiveCD, state.AutoReset, state.Unknown
pkg/state/steps_shared.go:477:2:  missing cases in switch of type state.Boot: state.LiveCD, state.AutoReset, state.Unknown
```

Both bugs, in under a second, before either could ship.

## The one setting that matters

`default-signifies-exhaustive` stays `false`, and I put a comment in the config saying why. **All three bugs had a `default` arm.** Set it to `true` and the linter reports none of them. Anyone tempted to flip it to quiet the noise should read the comment first.

## What changed in the code

Four switches now name `state.LiveCD` and `state.Unknown` explicitly rather than letting them fall through to `default`. **No behaviour changes** — each new case returns exactly what `default` returned.

The `default` arms stay as a backstop. The value is that the next boot state added to `kairos-sdk` fails the lint here, rather than reaching a `default` arm that silently does nothing. That is exactly how `AutoReset` got in.

## Scope

I checked the rest of the org: `kairos-agent`, `AuroraBoot` and `kairos-init` have no switch over `BootState`. immucore is the only consumer, so this is the only repository that needs it.

## Verified

```
go build ./...           ok
go test ./... -count=1   ok, every package
exhaustive ./...         clean
```

I validated the config keys against the official golangci-lint v2 JSON schema: `linters.settings.exhaustive.default-signifies-exhaustive` is a boolean, default `false`.

I did not run golangci-lint v2 itself — this machine has v1.64.8, which cannot read a v2 config. The lint job on this pull request is the real check.

---

AI assisted this pull request. Mauro is attending and directed it.
